### PR TITLE
Workflow execution extension to multiple resource collections

### DIFF
--- a/rodan/jobs/helloworld/helloworld.py
+++ b/rodan/jobs/helloworld/helloworld.py
@@ -29,6 +29,45 @@ class HelloWorld(RodanTask):
         outfile.close()
         return True
 
+class HelloWorldMultiPort(RodanTask):
+    name = 'Hello World Multiple Ports'
+    author = 'Studio theYANG'
+    description = 'Concatenate all input files and append "Hello World MultiPort"'
+    settings = {}
+    enabled = True
+    category = "Test"
+    interactive = False
+
+    input_port_types = (
+        {
+            'name': 'Text input',
+            'minimum': 0,
+            'maximum': 10,
+            'resource_types': ['text/plain']
+        },
+    )
+    output_port_types = (
+        {
+            'name': 'Text output',
+            'minimum': 1,
+            'maximum': 10,
+            'resource_types': ['text/plain']
+        },
+    )
+
+    def run_my_task(self, inputs, settings, outputs):
+        concatenated = ""
+        for input_type in inputs:
+            for input in inputs[input_type]:
+                with open(input["resource_path"], "r") as infile:
+                    concatenated += infile.read() + "\n"
+
+        for output_type in outputs:
+            for output in outputs[output_type]:
+                with open(output["resource_path"], "w") as outfile:
+                    outfile.write(concatenated)
+                    outfile.write("Hello World MultiPort")
+
 class HelloWorld3(RodanTask):
     name = 'Hello World - Python3'
     author = 'Alex Daigle'

--- a/rodan/jobs/master_task.py
+++ b/rodan/jobs/master_task.py
@@ -80,7 +80,7 @@ def master_task(workflow_run_id):
             if not settings.TEST:
                 if (
                     user.email
-                    and settings.EMAIL_USE
+                    and getattr(settings, 'EMAIL_USE', False)
                     and user.user_preference.send_email
                 ):
                     subject = "Workflow Run '{0}' FINISHED".format(workflowrun.name)

--- a/rodan/test/helpers.py
+++ b/rodan/test/helpers.py
@@ -357,6 +357,97 @@ class RodanTestSetUpMixin(object):
             self.url(self.test_Dip3): [self.url(self.test_resourcelist)],
         }
 
+    def setUp_funnel_dummy_workflow(self):
+        """
+        Set up the following funnel-shaped workflow:
+
+            test_wfjob_A  \
+            test_wfjob_B  - test_wfjob_D
+            test_wfjob_C  /
+        """
+        from rodan.test.dummy_jobs import dummy_automatic_job, dummy_manual_job
+
+        job_a = Job.objects.get(name=dummy_automatic_job.name)
+        job_m = Job.objects.get(name=dummy_manual_job.name)
+
+        ipt_aA = job_a.input_port_types.get(name="in_typeA")
+        opt_aA = job_a.output_port_types.get(name="out_typeA")
+
+        ipt_mA = job_m.input_port_types.get(name="in_typeA")
+        opt_mA = job_m.output_port_types.get(name="out_typeA")
+
+        self.test_project = mommy.make("rodan.Project")
+        self.test_workflow = mommy.make("rodan.Workflow", project=self.test_project)
+
+        self.test_wfjob_A = mommy.make(
+            "rodan.WorkflowJob",
+            workflow=self.test_workflow,
+            job=job_a,
+            job_settings={"a": 1, "b": [0.4]},
+        )
+        self.test_wfjob_B = mommy.make(
+            "rodan.WorkflowJob",
+            workflow=self.test_workflow,
+            job=job_m,
+            job_settings={"a": 1, "b": [0.4]},
+        )
+        self.test_wfjob_C = mommy.make(
+            "rodan.WorkflowJob",
+            workflow=self.test_workflow,
+            job=job_a,
+            job_settings={"a": 1, "b": [0.4]},
+        )
+        self.test_wfjob_D = mommy.make(
+            "rodan.WorkflowJob",
+            workflow=self.test_workflow,
+            job=job_m,
+            job_settings={"a": 1, "b": [0.4]},
+        )
+
+        self.test_Aip = mommy.make(
+            "rodan.InputPort", workflow_job=self.test_wfjob_A, input_port_type=ipt_aA
+        )
+        self.test_Aop = mommy.make(
+            "rodan.OutputPort", workflow_job=self.test_wfjob_A, output_port_type=opt_aA
+        )
+
+        self.test_Bip = mommy.make(
+            "rodan.InputPort", workflow_job=self.test_wfjob_B, input_port_type=ipt_mA
+        )
+        self.test_Bop = mommy.make(
+            "rodan.OutputPort", workflow_job=self.test_wfjob_B, output_port_type=opt_mA
+        )
+
+        self.test_Cip = mommy.make(
+            "rodan.InputPort", workflow_job=self.test_wfjob_C, input_port_type=ipt_aA
+        )
+        self.test_Cop = mommy.make(
+            "rodan.OutputPort", workflow_job=self.test_wfjob_C, output_port_type=opt_aA
+        )
+
+        self.test_Dip1 = mommy.make(
+            "rodan.InputPort", workflow_job=self.test_wfjob_D, input_port_type=ipt_mA
+        )
+        self.test_Dip2 = mommy.make(
+            "rodan.InputPort", workflow_job=self.test_wfjob_D, input_port_type=ipt_mA
+        )
+        self.test_Dip3 = mommy.make(
+            "rodan.InputPort", workflow_job=self.test_wfjob_D, input_port_type=ipt_mA
+        )
+        self.test_Dop = mommy.make(
+            "rodan.OutputPort", workflow_job=self.test_wfjob_D, output_port_type=opt_mA
+        )
+
+        self.test_conn_Aop_Dip1 = mommy.make(
+            "rodan.Connection", output_port=self.test_Aop, input_port=self.test_Dip1
+        )
+        self.test_conn_Aop_Dip2 = mommy.make(
+            "rodan.Connection", output_port=self.test_Bop, input_port=self.test_Dip2
+        )
+        self.test_conn_Aop_Dip3 = mommy.make(
+            "rodan.Connection", output_port=self.test_Cop, input_port=self.test_Dip3
+        )
+
 
 class RodanTestTearDownMixin(object):
     """


### PR DESCRIPTION
## Gist

A workflow should accept the input of multiple resource collections that share the same length (greater than 1). The engine should iterate through the collections at the same time to produce the workflow run results (much like how Python `zip()` works).

## Changes

- Loosen the validation of workflowrun creation to multiple resource collections of same length.
- Adapt `core.create_workflowrun` so that it correctly iterates through multiple resource collections when creating objects under the workflowrun.
- Add new hello world job that supports multiple ports for easier testing.
- Fix an outdated error message from workflowrun creation.
- Fix an unreferenced setting `settings.EMAIL_USE` (because it is by default not provided at all in settings.py)

## Proof

Video: https://vimeo.com/382214288 (password: rodan)

## Pending doc updates

<img width="651" alt="Screen Shot 2019-12-14 at 7 54 48 PM" src="https://user-images.githubusercontent.com/8630726/70857725-156a5400-1ec2-11ea-82cf-5112e5cecfc1.png">

<img width="737" alt="Screen Shot 2019-12-10 at 4 23 27 PM" src="https://user-images.githubusercontent.com/8630726/70573298-af06ce00-1b6f-11ea-99f4-b51e4c2a2915.png">

<img width="737" alt="Screen Shot 2019-12-10 at 5 06 21 PM" src="https://user-images.githubusercontent.com/8630726/70573299-b037fb00-1b6f-11ea-9a92-02e095ab1015.png">