### PR TITLE
Use a ResourceSerializer when deleting a resource

### DIFF
--- a/rodan/views/resource.py
+++ b/rodan/views/resource.py
@@ -174,11 +174,11 @@ class ResourceDetail(generics.RetrieveUpdateDestroyAPIView):
                 registry.tasks['rodan.core.create_diva'].si(resource.uuid).apply_async()
 
         return self.partial_update(request, *args, **kwargs)
-    
+
     def delete(self, request, *args, **kwargs):
 
         resource = self.get_object()
-        old_data = copy.deepcopy(resource)
+        old_data = ResourceSerializer(resource, context={'request': request}).data
 
         try:
             resource.delete()


### PR DESCRIPTION
We need to give some information on the resource we are deleting when
responding to client so use a ResourceSerializer to do that.