### PR TITLE
Reduce occurrances of SIGKILL issue

### DIFF
--- a/rodan/jobs/core.py
+++ b/rodan/jobs/core.py
@@ -176,40 +176,40 @@ def create_diva(resource_id):
     }
 
     task_image = inputs["Image"][0]["resource_path"]
-    _, tmp_file = tempfile.mkstemp(suffix=".tiff")
+    with tempfile.NamedTemporaryFile(suffix=".tiff") as tmp_file:
 
-    name = os.path.basename(tmp_file)
-    name, ext = os.path.splitext(name)
+        name = os.path.basename(tmp_file.name)
+        name, ext = os.path.splitext(name)
 
-    subprocess.check_call(
-        args=[
-            BIN_GM,
-            "convert",
-            "-depth", "8",  # output RGB
-            "-compress", "None",
-            task_image,  # image file input
-            tmp_file  # tiff file output
-        ]
-    )
+        subprocess.check_call(
+            args=[
+                BIN_GM,
+                "convert",
+                "-depth", "8",  # output RGB
+                "-compress", "None",
+                task_image,  # image file input
+                tmp_file.name  # tiff file output
+            ]
+        )
 
-    # With Kakadu
-    subprocess.check_call(
-        args=[
-            BIN_KDU_COMPRESS,
-            "-i", tmp_file,
-            "-o", name + ".jp2",
-            "-quiet",
-            "Clevels=5",
-            "Cblk={64,64}",
-            "Cprecincts={256,256},{256,256},{128,128}",
-            "Creversible=yes",
-            "Cuse_sop=yes",
-            "Corder=LRCP",
-            "ORGgen_plt=yes",
-            "ORGtparts=R",
-            "-rate", "-,1,0.5,0.25"
-        ]
-    )
+        # With Kakadu
+        subprocess.check_call(
+            args=[
+                BIN_KDU_COMPRESS,
+                "-i", tmp_file.name,
+                "-o", name + ".jp2",
+                "-quiet",
+                "Clevels=5",
+                "Cblk={64,64}",
+                "Cprecincts={256,256},{256,256},{128,128}",
+                "Creversible=yes",
+                "Cuse_sop=yes",
+                "Corder=LRCP",
+                "ORGgen_plt=yes",
+                "ORGtparts=R",
+                "-rate", "-,1,0.5,0.25"
+            ]
+        )
 
     # With OpenJPEG
     # creates a dark red tint on the image, it literally replaces the color profile.


### PR DESCRIPTION
When processing many new image resources at a time it's possible for the celery worker to run out of memory when calling graphics magick when preparing an image for use with diva.js. Rather than fail immediately, this lets the worker retry 3 times and wait 10 seconds each time. Usually by then enough memory will be freed for the process to succeed.