### PR TITLE
Add support for getting resources in zipfile

### DIFF
--- a/rodan/jobs/core.py
+++ b/rodan/jobs/core.py
@@ -1012,13 +1012,6 @@ def create_archive(resource_uuids):
     return temporary_storage
 
 
-@task(name="rodan.core.clean_buffer")
-def clean_buffer(buffer):
-    """
-    This is to free buffers used for rodan.core.create_archive
-    """
-    buffer.close()
-
 # app.tasks.register(create_resource())
 # app.tasks.register(package_results())
 # app.tasks.register(expire_package)

--- a/rodan/jobs/core.py
+++ b/rodan/jobs/core.py
@@ -6,6 +6,7 @@ import os
 # import re
 import shutil
 import subprocess
+import six
 import sys
 import tempfile
 import time
@@ -1006,7 +1007,7 @@ def create_archive(resource_uuids):
             # determine a path that doesn't conflict
             filepath = resource.name + "." + resource.resource_type.extension
             if filepath in archive.namelist():
-                for i in xrange(1, sys.maxint):
+                for i in six.moves.range(1, sys.maxint):
                     filepath = resource.name + " ({}).".format(i) + resource.resource_type.extension
                     if filepath not in archive.namelist():
                         break

--- a/rodan/jobs/core.py
+++ b/rodan/jobs/core.py
@@ -993,6 +993,9 @@ def create_archive(resource_uuids):
     for uuid in resource_uuids:
         condition |= Q(uuid=uuid)
     resources = Resource.objects.filter(Q(resource_file__isnull=False) & condition)
+    # Don't return an empty zip file
+    if resources.count() == 0:
+        return None
     temporary_storage = StringIO()
     with zipfile.ZipFile(temporary_storage, "a", zipfile.ZIP_DEFLATED) as archive:
         for resource in resources:

--- a/rodan/jobs/core.py
+++ b/rodan/jobs/core.py
@@ -5,6 +5,7 @@ import os
 # import re
 import shutil
 import subprocess
+import sys
 import tempfile
 import time
 import zipfile
@@ -1003,9 +1004,17 @@ def create_archive(resource_uuids):
                 print("{} has no file!".format(resource.name))
                 continue
 
+            # determine a path that doesn't conflict
+            filepath = resource.name + "." + resource.resource_type.extension
+            if filepath in archive.namelist():
+                for i in xrange(1, sys.maxint):
+                    filepath = resource.name + " ({}).".format(i) + resource.resource_type.extension
+                    if filepath not in archive.namelist():
+                        break
+
             archive.write(
                 resource.resource_file.path,
-                resource.name + "." + resource.resource_type.extension
+                filepath
             )
 
     temporary_storage.seek(0)

--- a/rodan/jobs/core.py
+++ b/rodan/jobs/core.py
@@ -1,12 +1,9 @@
 from __future__ import absolute_import
 
 from collections import OrderedDict
-from six import StringIO
 import os
-# import re
 import shutil
 import subprocess
-import six
 import sys
 import tempfile
 import time
@@ -20,6 +17,7 @@ from django.core.mail import EmailMessage
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q, Case, Value, When, BooleanField
 from pybagit.bagit import BagIt
+import six
 
 import rodan  # noqa
 from rodan.models import (
@@ -997,7 +995,7 @@ def create_archive(resource_uuids):
     # Don't return an empty zip file
     if resources.count() == 0:
         return None
-    temporary_storage = StringIO()
+    temporary_storage = six.StringIO()
     with zipfile.ZipFile(temporary_storage, "a", zipfile.ZIP_DEFLATED) as archive:
         for resource in resources:
             if not resource.resource_file:

--- a/rodan/jobs/core.py
+++ b/rodan/jobs/core.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from collections import OrderedDict
+from six import StringIO
 import os
 # import re
 import shutil
@@ -9,8 +10,6 @@ import sys
 import tempfile
 import time
 import zipfile
-
-from StringIO import StringIO
 
 from celery import task, registry
 from celery import Task

--- a/rodan/jobs/deep_eq.py
+++ b/rodan/jobs/deep_eq.py
@@ -24,7 +24,9 @@ import datetime
 import time
 import functools
 import operator
+import six
 import types
+
 
 default_fudge = datetime.timedelta(seconds=0, microseconds=0, days=0)
 
@@ -77,13 +79,13 @@ def deep_eq(_v1, _v2, datetime_fudge=default_fudge, _assert=False):
     >>> x10, y10 = (1, 2)
     >>> deep_eq(x10, y10)
     False
-    >>> deep_eq((str(p) for p in xrange(10)), (str(p) for p in xrange(10)))
+    >>> deep_eq((str(p) for p in six.moves.range(10)), (str(p) for p in six.moves.range(10)))
     True
-    >>> str(deep_eq(range(4), range(4)))
+    >>> str(deep_eq(six.moves.range(4), six.moves.range(4)))
     'True'
-    >>> deep_eq(xrange(100), xrange(100))
+    >>> deep_eq(six.moves.range(100), six.moves.range(100))
     True
-    >>> deep_eq(xrange(2), xrange(5))
+    >>> deep_eq(six.moves.range(2), six.moves.range(5))
     False
     >>> import datetime
     >>> from datetime import datetime as dt

--- a/rodan/jobs/deep_eq.py
+++ b/rodan/jobs/deep_eq.py
@@ -24,7 +24,7 @@ import datetime
 import time
 import functools
 import operator
-import six
+import six      # noqa
 import types
 
 

--- a/rodan/jobs/deep_eq.py
+++ b/rodan/jobs/deep_eq.py
@@ -24,7 +24,7 @@ import datetime
 import time
 import functools
 import operator
-import six      # noqa
+import six  # noqa
 import types
 
 

--- a/rodan/jobs/diva_generate_json.py
+++ b/rodan/jobs/diva_generate_json.py
@@ -22,6 +22,7 @@
 import os
 import re
 import math
+import six
 import sys
 import json
 from optparse import OptionParser
@@ -86,7 +87,7 @@ class GenerateJson(object):
         for im in images:
             page_data = []
 
-            for j in xrange(lowest_max_zoom + 1):
+            for j in six.moves.range(lowest_max_zoom + 1):
                 h = self.__incorporate_zoom(im['mx_h'], lowest_max_zoom - j)
                 w = self.__incorporate_zoom(im['mx_w'], lowest_max_zoom - j)
                 # if the dimensions of the original image are an exact multiple of 256
@@ -126,7 +127,7 @@ class GenerateJson(object):
                 'f': fn
             })
 
-        for j in xrange(lowest_max_zoom + 1):
+        for j in six.moves.range(lowest_max_zoom + 1):
             a_wid.append(t_wid[j] / float(len(images)))
             a_hei.append(t_hei[j] / float(len(images)))
 

--- a/rodan/settings.py
+++ b/rodan/settings.py
@@ -123,8 +123,8 @@ ENABLE_DIVA = True
 RODAN_WORKFLOW_SERIALIZATION_FORMAT_VERSION = 0.1
 # 30 days. NULL: never expire
 RODAN_RESULTS_PACKAGE_AUTO_EXPIRY_SECONDS = 30 * 24 * 60 * 60
-# Default: 999999 seconds before the authentication token expires.
-RODAN_RUNJOB_WORKING_USER_EXPIRY_SECONDS = 999999
+# Default: 15 seconds before the authentication token expires.
+RODAN_RUNJOB_WORKING_USER_EXPIRY_SECONDS = 15
 
 ###############################################################################
 # 1.c  Rodan Job Package Registration
@@ -138,17 +138,17 @@ BASE_JOB_PACKAGES = [
 ]
 RODAN_PYTHON2_JOBS = [
     #py2 "rodan.jobs.diagonal-neume-slicing",
-    "rodan.jobs.gamera_rodan",
-    "rodan.jobs.helloworld",
+    #py2 "rodan.jobs.gamera_rodan",
+    #py2 "rodan.jobs.helloworld",
     #py2 "rodan.jobs.heuristic-pitch-finding",
     #py2 "rodan.jobs.interactive_classifier",
     #py2 "rodan.jobs.JSOMR2MEI",
-    "rodan.jobs.neon-wrapper",
     #py2 "rodan.jobs.jSymbolic-Rodan",
-    "rodan.jobs.MEI_encoding",
+    #py2 "rodan.jobs.MEI_encoding",
+    #py2 "rodan.jobs.neon-wrapper",
     #py2 "rodan.jobs.pil-rodan",
-    "rodan.jobs.pixel_wrapper",
-    "rodan.jobs.text_alignment",
+    #py2 "rodan.jobs.pixel_wrapper",
+    #py2 "rodan.jobs.text_alignment",
     #py2 "rodan.jobs.vis-rodan",
 ]
 RODAN_PYTHON3_JOBS = [

--- a/rodan/settings.py
+++ b/rodan/settings.py
@@ -123,8 +123,8 @@ ENABLE_DIVA = True
 RODAN_WORKFLOW_SERIALIZATION_FORMAT_VERSION = 0.1
 # 30 days. NULL: never expire
 RODAN_RESULTS_PACKAGE_AUTO_EXPIRY_SECONDS = 30 * 24 * 60 * 60
-# Default: 15 seconds before the authentication token expires.
-RODAN_RUNJOB_WORKING_USER_EXPIRY_SECONDS = 15
+# Default: 999999 seconds before the authentication token expires.
+RODAN_RUNJOB_WORKING_USER_EXPIRY_SECONDS = 999999
 
 ###############################################################################
 # 1.c  Rodan Job Package Registration
@@ -138,17 +138,17 @@ BASE_JOB_PACKAGES = [
 ]
 RODAN_PYTHON2_JOBS = [
     #py2 "rodan.jobs.diagonal-neume-slicing",
-    #py2 "rodan.jobs.gamera_rodan",
-    #py2 "rodan.jobs.helloworld",
+    "rodan.jobs.gamera_rodan",
+    "rodan.jobs.helloworld",
     #py2 "rodan.jobs.heuristic-pitch-finding",
     #py2 "rodan.jobs.interactive_classifier",
     #py2 "rodan.jobs.JSOMR2MEI",
+    "rodan.jobs.neon-wrapper",
     #py2 "rodan.jobs.jSymbolic-Rodan",
-    #py2 "rodan.jobs.MEI_encoding",
-    #py2 "rodan.jobs.neon-wrapper",
+    "rodan.jobs.MEI_encoding",
     #py2 "rodan.jobs.pil-rodan",
-    #py2 "rodan.jobs.pixel_wrapper",
-    #py2 "rodan.jobs.text_alignment",
+    "rodan.jobs.pixel_wrapper",
+    "rodan.jobs.text_alignment",
     #py2 "rodan.jobs.vis-rodan",
 ]
 RODAN_PYTHON3_JOBS = [

--- a/rodan/test/views/test_resource.py
+++ b/rodan/test/views/test_resource.py
@@ -301,7 +301,7 @@ class ResourceArchiveTestCase(
     def test_get_invalid_uuid(self):
         response = self.client.get(
             "/api/resources/archive/",
-            { "resource_uuid": ["00000000-0000-0000-0000-000000000000"]}
+            {"resource_uuid": ["00000000-0000-0000-0000-000000000000"]}
         )
         anticipated_message = {
             "resource_uuid": ["The specified resources must exist."]

--- a/rodan/test/views/test_resource.py
+++ b/rodan/test/views/test_resource.py
@@ -1,13 +1,14 @@
 import os
 import tempfile
 import zipfile
-from StringIO import StringIO
+# from StringIO import StringIO
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from model_mommy import mommy
 from PIL import Image
 from rest_framework.test import APITestCase
 from rest_framework import status
+import six
 
 from rodan.constants import task_status
 from rodan.test.helpers import RodanTestSetUpMixin, RodanTestTearDownMixin
@@ -206,7 +207,7 @@ class ResourceProcessingTestCase(
         # kakadu.
 
         if os.environ.get("TRAVIS", "False") != "true":
-            file_obj = StringIO()
+            file_obj = six.StringIO()
             image = Image.new("RGB", size=(50, 50), color=(256, 0, 0))
             image.save(file_obj, "png")
             file_obj.name = "page1.png"
@@ -228,7 +229,7 @@ class ResourceProcessingTestCase(
             self.assertEqual(self.test_resource1.resource_type.mimetype, "image/rgb+png")
 
     def test_post_image_claiming_txt(self):
-        file_obj = StringIO()
+        file_obj = six.StringIO()
         image = Image.new("RGBA", size=(50, 50), color=(256, 0, 0))
         image.save(file_obj, "png")
         file_obj.name = "page1.png"

--- a/rodan/test/views/test_workflow.py
+++ b/rodan/test/views/test_workflow.py
@@ -7,6 +7,7 @@ from rest_framework.test import APITestCase
 
 from model_mommy import mommy
 from rodan.test.helpers import RodanTestSetUpMixin, RodanTestTearDownMixin
+import six
 import uuid
 from rodan.serializers.workflow import version_map
 
@@ -149,7 +150,7 @@ class WorkflowViewTestCase(RodanTestTearDownMixin, APITestCase, RodanTestSetUpMi
         self.assertEqual(response.data["error_code"], "IP_TOO_MANY_CONNECTIONS")
 
     def test_input__more_than_maximum(self):
-        for i in range(self.test_inputporttype.maximum):
+        for i in six.moves.range(self.test_inputporttype.maximum):
             ip = mommy.make(  # noqa
                 "rodan.InputPort",
                 workflow_job=self.test_workflowjob,
@@ -179,7 +180,7 @@ class WorkflowViewTestCase(RodanTestTearDownMixin, APITestCase, RodanTestSetUpMi
         self.assertEqual(response.data["error_code"], "OP_TYPE_MISMATCH")
 
     def test_output__more_than_maximum(self):
-        for o in range(self.test_outputporttype.maximum):
+        for o in six.moves.range(self.test_outputporttype.maximum):
             op = mommy.make(  # noqa
                 "rodan.OutputPort",
                 workflow_job=self.test_workflowjob,

--- a/rodan/test/views/test_workflowrun.py
+++ b/rodan/test/views/test_workflowrun.py
@@ -1,5 +1,6 @@
 import os
 import json
+import six
 from rest_framework.test import APITestCase
 from rest_framework import status
 from rest_framework.reverse import reverse
@@ -160,7 +161,7 @@ class WorkflowRunResourceAssignmentTest(
         ra[self.url(self.test_Fip1)] = [self.url(self.test_resource)]
 
         resource_lists = []
-        for i in range(10):
+        for i in six.moves.range(10):
             rl = mommy.make(
                 "rodan.ResourceList",
                 project=self.test_project,

--- a/rodan/urls.py
+++ b/rodan/urls.py
@@ -45,6 +45,7 @@ from rodan.views.resource import (
     ResourceDetail,
     ResourceViewer,
     ResourceAcquireView,
+    ResourceArchive,
 )
 from rodan.views.resourcelabel import ResourceLabelList, ResourceLabelDetail
 from rodan.views.resourcelist import ResourceListList, ResourceListDetail
@@ -219,6 +220,7 @@ api_patterns = [
         name="inputport-detail",
     ),
     url(r"^api/resources/$", ResourceList.as_view(), name="resource-list"),
+    url(r"^api/resources/archive/$", ResourceArchive.as_view(), name="resource-archive"),
     url(
         r"^api/resource/(?P<pk>[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/$",
         ResourceDetail.as_view(),
@@ -235,7 +237,8 @@ api_patterns = [
         name="resource-viewer-acquire",
     ),
     url(r"^api/labels/$", ResourceLabelList.as_view(), name="resourcelabel-list"),
-    url(r"^api/label/(?P<pk>[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/$",
+    url(
+        r"^api/label/(?P<pk>[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})/$",
         ResourceLabelDetail.as_view(),
         name="resourcelabel-detail",
     ),

--- a/rodan/views/main.py
+++ b/rodan/views/main.py
@@ -65,6 +65,7 @@ class APIRoot(APIView):
                 "resourcelists": reverse(
                     "resourcelist-list", request=request, format=format
                 ),
+                "resource-archive": reverse("resource-archive", request=request, format=format),
                 "resourcetypes": reverse(
                     "resourcetype-list", request=request, format=format
                 ),

--- a/rodan/views/main.py
+++ b/rodan/views/main.py
@@ -65,7 +65,7 @@ class APIRoot(APIView):
                 "resourcelists": reverse(
                     "resourcelist-list", request=request, format=format
                 ),
-                "resource-archive": reverse("resource-archive", request=request, format=format),
+                "resource-archive": reverse("resource-archive", request=request),
                 "resourcetypes": reverse(
                     "resourcetype-list", request=request, format=format
                 ),

--- a/rodan/views/main.py
+++ b/rodan/views/main.py
@@ -65,7 +65,7 @@ class APIRoot(APIView):
                 "resourcelists": reverse(
                     "resourcelist-list", request=request, format=format
                 ),
-                "resource-archive": reverse("resource-archive", request=request),
+                "resource-archive": reverse("resource-archive", request=request, format=format),
                 "resourcetypes": reverse(
                     "resourcetype-list", request=request, format=format
                 ),

--- a/rodan/views/resource.py
+++ b/rodan/views/resource.py
@@ -387,12 +387,14 @@ class ResourceAcquireView(generics.GenericAPIView):
         })
 
 
-class ResourceArchive(APIView):
+class ResourceArchive(generics.GenericAPIView):
     """
     Create and return an archive of resource files
     """
 
     permission_classes = (permissions.IsAuthenticated,)
+    queryset = Resource.objects.all()
+    serializer_class = ResourceSerializer
 
     def get(self, request, format=None):
         resource_uuids = request.query_params.getlist('resource_uuid', None)

--- a/rodan/views/resource.py
+++ b/rodan/views/resource.py
@@ -395,9 +395,9 @@ class ResourceArchive(APIView):
     permission_classes = (permissions.IsAuthenticated,)
 
     def get(self, request, format=None):
-        resource_uuids = request.query_params.getlist('resource_uuids', None)
+        resource_uuids = request.query_params.getlist('resource_uuid', None)
         if not resource_uuids:
-            raise ValidationError({'resource_uuids': ["You must supply a list of resource UUIDs."]})
+            raise ValidationError({'resource_uuid': ["You must supply a list of resource UUIDs."]})
 
         archive = registry.tasks['rodan.core.create_archive'].si(resource_uuids).apply_async()
         storage = archive.get()

--- a/rodan/views/resource.py
+++ b/rodan/views/resource.py
@@ -403,6 +403,8 @@ class ResourceArchive(generics.GenericAPIView):
 
         archive = registry.tasks['rodan.core.create_archive'].si(resource_uuids).apply_async(queue="celery")
         storage = archive.get()
+        if storage is None:
+            raise ValidationError({'resource_uuid': ["The specified resources must exist."]})
         # Allow 30 minutes for download
         registry.tasks['rodan.core.clean_buffer'].si(storage).apply_async(queue="celery", countdown=1800)
         response = FileResponse(

--- a/rodan/views/resource.py
+++ b/rodan/views/resource.py
@@ -401,10 +401,10 @@ class ResourceArchive(generics.GenericAPIView):
         if not resource_uuids:
             raise ValidationError({'resource_uuid': ["You must supply a list of resource UUIDs."]})
 
-        archive = registry.tasks['rodan.core.create_archive'].si(resource_uuids).apply_async()
+        archive = registry.tasks['rodan.core.create_archive'].si(resource_uuids).apply_async(queue="celery")
         storage = archive.get()
         # Allow 30 minutes for download
-        registry.tasks['rodan.core.clean_buffer'].si(storage).apply_async(countdown=1800)
+        registry.tasks['rodan.core.clean_buffer'].si(storage).apply_async(queue="celery", countdown=1800)
         response = FileResponse(
             storage,
             content_type="application/zip"

--- a/rodan/views/resource.py
+++ b/rodan/views/resource.py
@@ -406,6 +406,7 @@ class ResourceArchive(generics.GenericAPIView):
         storage = archive.get()
         if storage is None:
             raise ValidationError({'resource_uuid': ["The specified resources must exist."]})
+        print("Have response")
         response = FileResponse(
             storage,
             content_type="application/zip"

--- a/rodan/views/resource.py
+++ b/rodan/views/resource.py
@@ -401,7 +401,8 @@ class ResourceArchive(generics.GenericAPIView):
         if not resource_uuids:
             raise ValidationError({'resource_uuid': ["You must supply a list of resource UUIDs."]})
 
-        archive = registry.tasks['rodan.core.create_archive'].si(resource_uuids).apply_async(queue="celery")
+        archive = registry.tasks['rodan.core.create_archive'] \
+            .si(resource_uuids).apply_async(queue="celery")
         storage = archive.get()
         if storage is None:
             raise ValidationError({'resource_uuid': ["The specified resources must exist."]})

--- a/rodan/views/resource.py
+++ b/rodan/views/resource.py
@@ -405,8 +405,6 @@ class ResourceArchive(generics.GenericAPIView):
         storage = archive.get()
         if storage is None:
             raise ValidationError({'resource_uuid': ["The specified resources must exist."]})
-        # Allow 30 minutes for download
-        registry.tasks['rodan.core.clean_buffer'].si(storage).apply_async(queue="celery", countdown=1800)
         response = FileResponse(
             storage,
             content_type="application/zip"


### PR DESCRIPTION
Creates and serves a zipfile based on requests to the `/api/resources/archive`. GET request with parameters as resource UUIDs results in a zipfile being generated and returned by `rodan.core.create_archive`. ~This is stored in memory for 30 minutes, when it is deleted.~ FileResponse handles deletion of the zipfile from memory.