### PR TITLE
Include references to MEI_resizing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ rodan/jobs/MEI_encoding
 rodan/jobs/text_alignment
 rodan/jobs/hpc-fast-trainer
 rodan/jobs/biollante-rodan
+rodan/jobs/MEI_resizing
 
 /.DS_Store
 

--- a/rodan/settings.py
+++ b/rodan/settings.py
@@ -151,6 +151,7 @@ RODAN_PYTHON2_JOBS = [
     #py2 "rodan.jobs.text_alignment",
     #py2 "rodan.jobs.vis-rodan",
     #py2 "rodan.jobs.biollante-rodan",
+    #py2 "rodan.jobs.MEI_resizing",
 ]
 RODAN_PYTHON3_JOBS = [
     #py3 "rodan.jobs.helloworld",


### PR DESCRIPTION
This adds the MEI_resizing job to the excludes in the `rodan/jobs` folder and includes it as a commented out Python2 job.