### PR TITLE
Update requirements.txt to aquire security patches 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ gnureadline==6.3.3
 gunicorn==19.10.0
 jsonfield==1.0.0
 jsonschema==2.5.1
-lxml==3.4.0
+lxml==4.6.3
 Markdown==2.5.1
 mimeparse==0.1.3
 model-mommy==1.6.0
@@ -30,7 +30,7 @@ pyparsing==2.0.3
 pypng==0.0.18
 python-dateutil==2.5
 python-magic==0.4.22
-PyYAML==5.3.1
+PyYAML==5.4
 readline==6.2.4.1
 redis==2.10.3
 uWSGI==2.0.18


### PR DESCRIPTION
Updated lxml to 4.6.3 and PyYAML to 5.4 in order to aquire security patches. Tested changes locally in rodan-docker and everything seemed fine, however I'll create a PR into develop rather than commiting so that someone else can test the changes -- don't wanna break the Celery-updated version on a Sunday.

Edit: Couldn't update Pillow and djangorestframework as the secure versions no longer support Python 2.7 -- a familiar story. 