### PR TITLE
Remove rodan git clones

### DIFF
--- a/gpu-celery/Dockerfile
+++ b/gpu-celery/Dockerfile
@@ -140,14 +140,19 @@ COPY ./rodan/scripts/entrypoint /opt/
 COPY ./rodan/scripts/start-celery /run/
 COPY ./rodan/scripts/wait-for-app /run/
 
+# Copying rodan core from build context into container
+# Rodan folder MUST be uppercase, otherwise many unittests fail.
+COPY ./rodan/code /code/Rodan
+
 # necessary for scikit-image > 0.17, or else it will try to make a cache directory
 # in a place where the www-data user does not have permissions to do so
 ENV SKIMAGE_DATADIR "/tmp/.skimage_cache"
 
+
 RUN set -x \
   # Create Folders
   && mkdir -p /code/jobs \
-  && git clone -b ${BRANCHES} https://github.com/DDMAL/Rodan.git /code/Rodan \
+  #&& git clone -b ${BRANCHES} https://github.com/DDMAL/Rodan.git /code/Rodan \
   # Install GPU Jobs
   && chmod +x /opt/install_gpu_rodan_jobs \
   && chown www-data /opt/install_gpu_rodan_jobs \

--- a/gpu-celery/Dockerfile
+++ b/gpu-celery/Dockerfile
@@ -152,7 +152,6 @@ ENV SKIMAGE_DATADIR "/tmp/.skimage_cache"
 RUN set -x \
   # Create Folders
   && mkdir -p /code/jobs \
-  #&& git clone -b ${BRANCHES} https://github.com/DDMAL/Rodan.git /code/Rodan \
   # Install GPU Jobs
   && chmod +x /opt/install_gpu_rodan_jobs \
   && chown www-data /opt/install_gpu_rodan_jobs \

--- a/python2-celery/Dockerfile
+++ b/python2-celery/Dockerfile
@@ -78,6 +78,7 @@ RUN rm -rf /var/lib/apt/lists/*
 # RUN pip install git+https://github.com/hsnr-gamera/gamera.git --global-option="--nowx"
 # pip broke again: https://github.com/pypa/pip/issues/6560
 # Let's not rely on pip to install this again.
+
 RUN set -e \
   && mkdir -p /rodan/data /code/jobs \
   && chown -R www-data /rodan \
@@ -86,11 +87,9 @@ RUN set -e \
   && cd /code/gamera \
   # && git reset --hard c77194d5e839204efc617971233967ba5a6c53bc \
   && git reset --hard  d8e4255a5e2d6d6e64528c8758d75f0afacf4d72 \
-  && python setup.py install --nowx >/dev/null 2>&1 \
+  && python setup.py install --nowx >/dev/null 2>&1
   # Prep for Rodan
-  # Rodan folder MUST be uppercase, otherwise many unittests fail.
-  && chown -R www-data /rodan \
-  && git clone -b ${BRANCHES} https://github.com/DDMAL/Rodan.git /code/Rodan
+  # && git clone -b ${BRANCHES} https://github.com/DDMAL/Rodan.git /code/Rodan
 
 # Install framework dependencies for Rodan Jobs.
 COPY ./rodan/scripts/install_rodan_job_dependencies /run/
@@ -99,6 +98,11 @@ COPY ./rodan/scripts/install_rodan /run/
 COPY ./rodan/scripts/wait-for-app /run/
 COPY ./rodan/scripts/entrypoint /opt/
 COPY ./rodan/scripts/start-celery /run/
+
+# Copying rodan core from build context into container
+# Rodan folder MUST be uppercase, otherwise many unittests fail.
+COPY ./rodan/code /code/Rodan
+
 
 RUN set -x \
   && chmod +x /run/install_rodan_job_dependencies \

--- a/python2-celery/Dockerfile
+++ b/python2-celery/Dockerfile
@@ -88,8 +88,6 @@ RUN set -e \
   # && git reset --hard c77194d5e839204efc617971233967ba5a6c53bc \
   && git reset --hard  d8e4255a5e2d6d6e64528c8758d75f0afacf4d72 \
   && python setup.py install --nowx >/dev/null 2>&1
-  # Prep for Rodan
-  # && git clone -b ${BRANCHES} https://github.com/DDMAL/Rodan.git /code/Rodan
 
 # Install framework dependencies for Rodan Jobs.
 COPY ./rodan/scripts/install_rodan_job_dependencies /run/

--- a/python3-celery/Dockerfile
+++ b/python3-celery/Dockerfile
@@ -26,10 +26,11 @@ COPY ./rodan/scripts/install_python3_rodan_jobs /run/
 COPY ./rodan/scripts/install_rodan /run/
 COPY ./rodan/scripts/start-celery /run/
 COPY ./rodan/scripts/wait-for-app /run/
+COPY ./rodan/code /code/Rodan
 
 RUN set -x \
   && mkdir -p /code/jobs \
-  && git clone -b ${BRANCHES} https://github.com/DDMAL/Rodan.git /code/Rodan \
+  # && git clone -b ${BRANCHES} https://github.com/DDMAL/Rodan.git /code/Rodan \
   # Install Python3 Rodan Jobs
   && chmod +x /run/install_python3_rodan_jobs \
   && chown www-data /run/install_python3_rodan_jobs \

--- a/python3-celery/Dockerfile
+++ b/python3-celery/Dockerfile
@@ -26,11 +26,13 @@ COPY ./rodan/scripts/install_python3_rodan_jobs /run/
 COPY ./rodan/scripts/install_rodan /run/
 COPY ./rodan/scripts/start-celery /run/
 COPY ./rodan/scripts/wait-for-app /run/
+
+# Copying rodan core from build context into container
+# Rodan folder MUST be uppercase, otherwise many unittests fail.
 COPY ./rodan/code /code/Rodan
 
 RUN set -x \
   && mkdir -p /code/jobs \
-  # && git clone -b ${BRANCHES} https://github.com/DDMAL/Rodan.git /code/Rodan \
   # Install Python3 Rodan Jobs
   && chmod +x /run/install_python3_rodan_jobs \
   && chown www-data /run/install_python3_rodan_jobs \


### PR DESCRIPTION
Removes the statements of `git clone https://github.com/DDMAL/Rodan.git` from all the dockerfiles, and instead just copies the rodan "core" code directly from within this repository now that it's all unified.