### PR TITLE
Add build_hash to Rodan API

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -13,6 +13,7 @@ docker build \
 RODAN_TAG=`cd rodan-main/code && git describe --tags --always`
 RODAN_CLIENT_TAG=`cd rodan-client/code && git describe --tags --always`
 RODAN_DOCKER_TAG=`git describe --tags --always`
+BUILD_HASH=`git rev-parse --verify HEAD`
 
 ###############################################################################
 # Stage 1
@@ -52,6 +53,7 @@ docker build \
   --no-cache \
   --build-arg BRANCHES="develop" \
   --build-arg VERSION=${RODAN_TAG} \
+  --build-arg build_hash=${BUILD_HASH} \
   --tag ddmal/rodan-main:nightly \
   --tag ddmal/rodan-main:${RODAN_TAG} \
   --file ./rodan-main/Dockerfile \

--- a/rodan-main/Dockerfile
+++ b/rodan-main/Dockerfile
@@ -1,6 +1,7 @@
 FROM ddmal/rodan-python2-celery:nightly
 ARG BRANCHES
 ARG VERSION
+ARG BUILD_HASH
 
 # Install OpenJPEG
 RUN \
@@ -46,5 +47,8 @@ RUN \
   /opt/install_python3_rodan_jobs \
   && /opt/install_gpu_rodan_jobs \
   && /run/install_rodan
+
+# Substitute the build hash for our actual build hash
+RUN sed -i "s/__build_hash__ = \"local\"/__build_hash__ = \"${BUILD_HASH}\"/" /code/Rodan/rodan/__init__.py
 
 ENTRYPOINT ["/opt/entrypoint"]

--- a/rodan-main/code/rodan/__init__.py
+++ b/rodan-main/code/rodan/__init__.py
@@ -19,3 +19,5 @@ from .celery import app as celery_app
 __title__ = "Rodan"
 __version__ = "2.0.0"
 __copyright__ = "Copyright 2011-2022 Distributed Digital Music Archives & Libraries Lab"
+# If changing this line, also change rodan-main/Dockerfile
+__build_hash__ = "local"

--- a/rodan-main/code/rodan/views/main.py
+++ b/rodan-main/code/rodan/views/main.py
@@ -98,6 +98,7 @@ class APIRoot(APIView):
                 "job_packages": package_versions,
             },
             "version": rodan.__version__,
+            "build_hash": rodan.__build_hash__,
         }
         return Response(response)
 


### PR DESCRIPTION
This PR exposes a new API endpoint called build_hash that tracks the Git commit hash at which `rodan-main` was built.

This is useful for implementing E2E tests, as it gives us a way to understand at which point the code has broken (when it does break).