### PR TITLE
Add paco_classifier to develop branch as a package

### DIFF
--- a/rodan-main/code/rodan/jobs/Paco_classifier/__init__.py
+++ b/rodan-main/code/rodan/jobs/Paco_classifier/__init__.py
@@ -1,0 +1,10 @@
+import rodan
+__version__ = "1.2.3"
+
+import logging
+logger = logging.getLogger('rodan')
+
+from rodan.jobs import module_loader
+
+module_loader('rodan.jobs.Paco_classifier.fast_calvo_classifier')
+module_loader('rodan.jobs.Paco_classifier.fast_calvo_trainer')

--- a/rodan-main/code/rodan/jobs/Paco_classifier/fast_calvo_classifier.py
+++ b/rodan-main/code/rodan/jobs/Paco_classifier/fast_calvo_classifier.py
@@ -1,0 +1,202 @@
+#-----------------------------------------------------------------------------
+# Program Name:         calvo_classifier.py
+# Program Description:  Rodan wrapper for Calvo's classifier
+#-----------------------------------------------------------------------------
+
+# Core
+# import json
+import os
+import sys
+import logging
+import collections
+
+# Third-party
+import cv2
+import numpy as np
+from celery.utils.log import get_task_logger
+from django.conf import settings as rodan_settings
+
+# Project
+from rodan.celery import app
+from rodan.jobs.base import RodanTask
+from rodan.models import Input
+
+"""Wrap Fast Calvo classifier in Rodan."""
+
+logger = get_task_logger(__name__)
+# logger = get_task_logger('rodan')
+
+class FastCalvoClassifier(RodanTask):
+    name = "Fast Pixelwise Analysis of Music Document, Classifying"
+    author = "Jorge Calvo-Zaragoza, Gabriel Vigliensoni, and Ichiro Fujinaga"
+    description = "Given a pre-trained Convolutional neural network, the job performs a (fast) pixelwise analysis of music document images." 
+    enabled = True
+    category = "OMR - Layout analysis"
+    interactive = False
+
+    settings = {
+        'title': 'Parameters',
+        'type': 'object',
+        'job_queue': 'GPU',
+        'properties': {
+            'Height': {
+                'type': 'integer',
+                'minimum': 1,
+                'default': 256
+            },
+            'Width': {
+                'type': 'integer',
+                'minimum': 1,
+                'default': 256
+            },
+            'Threshold': {
+                'type': 'integer',
+                'minimum': 0,
+                'maximum': 100,
+                'default': 50
+            }
+        },
+    }
+
+    input_port_types = (
+        {'name': 'Image', 'minimum': 1, 'maximum': 100, 'resource_types': lambda mime: mime.startswith('image/')},
+        {'name': 'Background model', 'minimum': 1, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
+        # We did not go this route because it would be more difficult for the user to track layers.
+        # {'name': 'Adjustable models', 'minimum': 1, 'maximum': 10, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Model 0', 'minimum': 1, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Model 1', 'minimum': 0, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Model 2', 'minimum': 0, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Model 3', 'minimum': 0, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Model 4', 'minimum': 0, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Model 5', 'minimum': 0, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Model 6', 'minimum': 0, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Model 7', 'minimum': 0, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Model 8', 'minimum': 0, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Model 9', 'minimum': 0, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
+    )
+    output_port_types = (
+        {'name': 'Log File', 'minimum': 0, 'maximum': 1, 'resource_types': ['text/plain']},
+        {'name': 'Background', 'minimum': 1, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        # We did not go this route because it would be more difficult for the user to track layers
+        # {'name': 'Layers', 'minimum': 1, 'maximum': 10, 'resource_types': ['image/rgba+png']},
+        {'name': 'Layer 0', 'minimum': 1, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Layer 1', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Layer 2', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Layer 3', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Layer 4', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Layer 5', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Layer 6', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Layer 7', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Layer 8', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Layer 9', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+    )
+
+    """
+    Entry point
+    """
+    def run_my_task(self, inputs, settings, outputs):
+        from Paco_classifier import recognition_engine as recognition
+
+        oldouts = sys.stdout, sys.stderr
+        if 'Log File' in outputs and len(outputs['Log File']) > 0:
+            handler = logging.FileHandler(outputs['Log File'][0]['resource_path'])
+            handler.setFormatter(
+                    logging.Formatter('%(asctime)s - %(name)s - %(message)s')
+            )
+            logger.addHandler(handler)
+        try:
+            # Settings
+            height = settings['Height']
+            width = settings['Width']
+            threshold = settings['Threshold']
+            rlevel = app.conf.CELERY_REDIRECT_STDOUTS_LEVEL
+            app.log.redirect_stdouts_to_logger(logger, rlevel)
+
+            # Inner configuration
+            mode = 'logical'
+
+            # Fail early if the number of ports doesn't match.
+            input_ports = len([x for x in inputs if x[:5] == 'Model'])
+            output_ports = len([x for x in outputs if x[:5] == 'Layer'])
+            if input_ports != output_ports:
+                raise Exception(
+                    'The number of input layers "Model" does not match the number of'
+                    ' output "Layer"'
+                )
+
+            # Ports
+            background_model = inputs['Background model'][0]['resource_path']
+            model_paths = [background_model]
+
+            # Populate optional ports
+            for i in range(input_ports):
+                model_paths += [inputs['Model %d' % i][0]['resource_path']]
+
+            # Simulate a switch statement, instead of a series of ifs
+            switch = {
+                0: 'Background',
+                1: 'Layer 0',
+                2: 'Layer 1',
+                3: 'Layer 2',
+                4: 'Layer 3',
+                5: 'Layer 4',
+                6: 'Layer 5',
+                7: 'Layer 6',
+                8: 'Layer 7',
+                9: 'Layer 8',
+                10: 'Layer 9',
+            }
+
+            # status = {
+            #     "inputs": inputs,
+            #     "outputs": outputs,
+            #     "input_ports": input_ports,
+            #     "output_ports": output_ports,
+            #     "input_": [x for x in inputs if x[:5] == "Model"],
+            #     "output_": [x for x in outputs if x[:5] == "Layer"],
+            #     "len_model_paths": len(model_paths),
+            #     "model_paths": model_paths,
+            #     "ports": []
+            # }
+
+            # Image input is a list of images, you can classify a list of images and this iterates on each image.
+            for idx, _ in enumerate(inputs['Image']):
+
+                # Process
+                image_filepath = inputs['Image'][idx]['resource_path']
+                image = cv2.imread(image_filepath, 1)
+                analyses = recognition.process_image_msae(image, model_paths, height, width, mode = mode)
+
+                for id_label, _ in enumerate(model_paths):
+                    if mode == 'masks':
+                        mask = ((analyses[id_label] > (threshold / 100.0)) * 255).astype('uint8')
+                    elif mode == 'logical':
+                        label_range = np.array(id_label, dtype=np.uint8)
+                        mask = cv2.inRange(analyses, label_range, label_range)
+     
+                    original_masked = cv2.bitwise_and(image, image, mask = mask)
+                    original_masked[mask == 0] = (255, 255, 255)
+
+                    # Alpha = 0 when background
+                    alpha_channel = np.ones(mask.shape, dtype=mask.dtype) * 255
+                    alpha_channel[mask == 0] = 0
+                    b_channel, g_channel, r_channel = cv2.split(original_masked)
+                    original_masked_alpha = cv2.merge((b_channel, g_channel, r_channel, alpha_channel))
+
+                    # status["ports"].append(
+                    #     {
+                    #         "switch": switch[id_label],
+                    #         "path": outputs[switch[id_label]][idx]['resource_path'],
+                    #     }
+                    # )
+                    if switch[id_label] in outputs:
+                        cv2.imwrite(outputs[switch[id_label]][idx]['resource_path']+'.png', original_masked_alpha)
+                        os.rename(outputs[switch[id_label]][idx]['resource_path']+'.png', outputs[switch[id_label]][idx]['resource_path'])
+
+            # raise Exception(json.dumps(status, indent=2))
+            return True
+        finally:
+            sys.stdout, sys.stderr = oldouts
+
+    def my_error_information(self, exc, traceback):
+        pass

--- a/rodan-main/code/rodan/jobs/Paco_classifier/fast_calvo_trainer.py
+++ b/rodan-main/code/rodan/jobs/Paco_classifier/fast_calvo_trainer.py
@@ -1,0 +1,173 @@
+# -----------------------------------------------------------------------------
+# Program Name:         calvo_trainer.py
+# Program Description:  Rodan wrapper for Fast Calvo's classifier training
+# -----------------------------------------------------------------------------
+
+# Core
+import os
+import sys
+import logging
+
+# Third-party
+import cv2
+import numpy as np
+import zipfile
+from shutil import rmtree
+from celery.utils.log import get_task_logger
+
+# Project
+from rodan.celery import app
+from rodan.jobs.base import RodanTask
+
+
+"""Wrap Patchwise (Fast) Calvo classifier training in Rodan."""
+
+logger = get_task_logger(__name__)
+
+
+class FastCalvoTrainer(RodanTask):
+    name = "Fast Pixelwise Analysis of Music Document, Training"
+    author = "Jorge Calvo-Zaragoza, Francisco J. Castellanos, Gabriel Vigliensoni, and Ichiro Fujinaga"
+    description = "The job performs the training of many Selection Auto-Encoder model for the pixelwise analysis of music document images."
+    enabled = True
+    category = "OMR - Layout analysis"
+    interactive = False
+
+    settings = {
+        'title': 'Training parameters',
+        'type': 'object',
+        'properties': {
+            'Batch Size': {
+                'type': 'integer',
+                'minimum': 1,
+                'default': 8,
+                'maximum': 64,
+            },
+            'Maximum number of training epochs': {
+                'type': 'integer',
+                'minimum': 1,
+                'default': 50
+            },
+            'Maximum number of samples per label': {
+                'type': 'integer',
+                'minimum': 1,
+                'default': 1000
+            },            
+            'Patch height': {
+                'type': 'integer',
+                'minimum': 32,
+                'default': 256
+            },
+            'Patch width': {
+                'type': 'integer',
+                'minimum': 32,
+                'default': 256
+            },
+        },
+        'job_queue': 'GPU'
+    }
+
+    input_port_types = (
+        {'name': 'Image', 'minimum': 1, 'maximum': 1, 'resource_types': ['application/zip']},
+        {'name': 'rgba PNG - Selected regions', 'minimum': 1, 'maximum': 1, 'resource_types': ['application/zip']},
+        # We did not go this route because it would be more difficult for the user to track layers
+        # {'name': 'rgba PNG - Layers', 'minimum': 1, 'maximum': 10, 'resource_types': ['image/rgba+png']},
+        {'name': 'rgba PNG - Layer 0 (Background)', 'minimum': 1, 'maximum': 1, 'resource_types': ['application/zip']},
+        {'name': 'rgba PNG - Layer 1', 'minimum': 1, 'maximum': 1, 'resource_types': ['application/zip']},
+        {'name': 'rgba PNG - Layer 2', 'minimum': 0, 'maximum': 1, 'resource_types': ['application/zip']},
+        {'name': 'rgba PNG - Layer 3', 'minimum': 0, 'maximum': 1, 'resource_types': ['application/zip']},
+        {'name': 'rgba PNG - Layer 4', 'minimum': 0, 'maximum': 1, 'resource_types': ['application/zip']},
+        {'name': 'rgba PNG - Layer 5', 'minimum': 0, 'maximum': 1, 'resource_types': ['application/zip']},
+        {'name': 'rgba PNG - Layer 6', 'minimum': 0, 'maximum': 1, 'resource_types': ['application/zip']},
+        {'name': 'rgba PNG - Layer 7', 'minimum': 0, 'maximum': 1, 'resource_types': ['application/zip']},
+        {'name': 'rgba PNG - Layer 8', 'minimum': 0, 'maximum': 1, 'resource_types': ['application/zip']},
+        {'name': 'rgba PNG - Layer 9', 'minimum': 0, 'maximum': 1, 'resource_types': ['application/zip']},
+    )
+
+    output_port_types = (
+        # We did not go this route because it would be more difficult for the user to track layers
+        # {'name': 'Adjustable models', 'minimum': 1, 'maximum': 10, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Log File', 'minimum': 1, 'maximum': 1, 'resource_types': ['text/plain']},
+        {'name': 'Model 0', 'minimum': 1, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Model 1', 'minimum': 1, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Model 2', 'minimum': 0, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Model 3', 'minimum': 0, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Model 4', 'minimum': 0, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Model 5', 'minimum': 0, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Model 6', 'minimum': 0, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Model 7', 'minimum': 0, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Model 8', 'minimum': 0, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Model 9', 'minimum': 0, 'maximum': 1, 'resource_types': ['keras/model+hdf5']}
+    )
+
+
+    def run_my_task(self, inputs, settings, outputs):
+        from Paco_classifier import input_settings_test
+        from Paco_classifier import training_engine_sae as training
+        from Paco_classifier.fast_trainer_lib import CalvoTrainer
+
+        oldouts = sys.stdout, sys.stderr
+        if 'Log File' in outputs:
+            handler = logging.FileHandler(outputs['Log File'][0]['resource_path'])
+            handler.setFormatter(
+                logging.Formatter('%(asctime)s - %(name)s - %(message)s')
+            )
+            logger.addHandler(handler)
+        try:
+            # Settings
+            batch_size = settings['Batch Size']
+            patch_height = settings['Patch height']
+            patch_width = settings['Patch width']
+            max_number_of_epochs = settings['Maximum number of training epochs']
+            number_samples_per_class = settings['Maximum number of samples per label']
+
+            #------------------------------------------------------------
+            #TODO Include the training options in the configuration data
+            file_selection_mode = training.FileSelectionMode.SHUFFLE 
+            sample_extraction_mode = training.SampleExtractionMode.RANDOM
+            #------------------------------------------------------------
+
+            # Unzip zip files into dictionary of images
+            if os.path.exists('unzipping_folder'):
+                rmtree('unzipping_folder')
+            os.mkdir('unzipping_folder')
+            new_input = {}
+            for ipt in inputs:
+                dir_path = 'unzipping_folder/{}'.format(ipt)
+                with zipfile.ZipFile(inputs[ipt][0]['resource_path'], 'r') as zip_ref:
+                    zip_ref.extractall(dir_path)
+                full_path = os.path.join(os.getcwd(), dir_path)
+                onlyfiles = [{'resource_path': os.path.join(full_path, f)} for f in os.listdir(dir_path) if os.path.isfile(os.path.join(dir_path, f))]
+                new_input[ipt] = onlyfiles
+
+            # SANITY CHECK
+            input_settings_test.pre_training_check(new_input, batch_size, patch_height, patch_width, number_samples_per_class)
+
+            rlevel = app.conf.CELERY_REDIRECT_STDOUTS_LEVEL
+            app.log.redirect_stdouts_to_logger(logger, rlevel)
+
+            # Fail if arbitrary layers are not equal before training occurs.
+            trainer = CalvoTrainer(
+                batch_size,
+                patch_height,
+                patch_width,
+                max_number_of_epochs,
+                number_samples_per_class,
+                file_selection_mode,
+                sample_extraction_mode,
+                # CHANGED HERE FOR UNZIP
+                new_input,
+                outputs,
+            )
+            trainer.runTrainer()
+
+            # REMOVE UNZIP FOLDER
+            if os.path.exists('unzipping_folder'):
+                rmtree('unzipping_folder')
+
+            return True
+        finally:
+            sys.stdout, sys.stderr = oldouts
+
+    def my_error_information(self, exc, traceback):
+        pass

--- a/rodan-main/code/rodan/jobs/Paco_classifier/resource_types.yaml
+++ b/rodan-main/code/rodan/jobs/Paco_classifier/resource_types.yaml
@@ -1,0 +1,15 @@
+- mimetype: image/rgb+png
+  description: RGB PNG image
+  extension: png
+- mimetype: image/rgb+jpg
+  description: JPG image file
+  extension: jpg
+- mimetype: image/rgba+png
+  description: PNG image file with alpha channel
+  extension: png
+- mimetype: keras/model+hdf5
+  description: Trained network from Keras framework
+  extension: hdf5
+- mimetype: application/zip
+  description: Zip file
+  extension: zip

--- a/rodan-main/code/rodan/jobs/register_all_jobs.py
+++ b/rodan-main/code/rodan/jobs/register_all_jobs.py
@@ -474,8 +474,6 @@ def register_py3():
 
 # GPU Jobs
 def register_gpu():
-
-
     # Register Calvo
     try:
         from rodan.jobs.Calvo_classifier.calvo_classifier import CalvoClassifier
@@ -519,6 +517,25 @@ def register_gpu():
     except Exception as exception:
         import_name = "Text Alignment"
         print(import_name + " failed to import with the following error:", exception.__class__.__name__)
+
+    # Register Paco's Trainer
+    try:
+        from rodan.jobs.Paco_classifier.fast_calvo_trainer import FastCalvoTrainer
+
+        app.register_task(FastCalvoTrainer())
+    except Exception as exception:
+        import_name = "Paco Trainer"
+        print(import_name + " failed to import with the following error:", exception.__class__.__name__)
+
+    # Register Paco's Classifier
+    try:
+        from rodan.jobs.Paco_classifier.fast_calvo_classifier import FastCalvoClassifier
+
+        app.register_task(FastCalvoClassifier())
+    except Exception as exception:
+        import_name = "Paco Classifier"
+        print(import_name + " failed to import with the following error:", exception.__class__.__name__)
+
 
 
 if __name__ == "__main__":

--- a/rodan-main/code/rodan/settings.py
+++ b/rodan-main/code/rodan/settings.py
@@ -159,6 +159,7 @@ RODAN_PYTHON3_JOBS = [
 RODAN_GPU_JOBS = [
     "rodan.jobs.Calvo_classifier",
     "rodan.jobs.text_alignment",
+    "rodan.jobs.Paco_classifier"
 ]
 
 if RODAN_JOB_QUEUE == "None" or RODAN_JOB_QUEUE == "celery":

--- a/scripts/install_gpu_rodan_jobs
+++ b/scripts/install_gpu_rodan_jobs
@@ -26,5 +26,14 @@ cd /code/Rodan/rodan/jobs
 # Install Text Alignment
 $PIP install -r ./text_alignment/requirements.txt
 
+# Install Paco classifier
+cd /
+git clone https://github.com/DDMAL/Paco_classifier.git
+mv Paco_classifier .Paco_classifier
+cd .Paco_classifier
+git fetch origin release
+git reset --hard origin/release
+which pip3 && $PIP install . 
+
 cd /code/Rodan/rodan
 sed -i 's/#gpu //g' /code/Rodan/rodan/settings.py


### PR DESCRIPTION
The result should be the same as #677, but Paco Classifier is installed as a python package with `pip install .` from [`ddmal/Paco_classifier:release`](https://github.com/DDMAL/Paco_classifier/tree/release), `rodan-main/code/rodan/jobs/Paco_classifier/` now only contains rodan job wrappers. Training/testing code goes to `ddmal/Paco_classifier:release`