### PR TITLE
Add typing extensions dependency to gpu container

### DIFF
--- a/gpu-celery/Dockerfile
+++ b/gpu-celery/Dockerfile
@@ -121,6 +121,8 @@ RUN set -e \
   && apt-get update \
   && DEBIAN_FRONTEND="noninteractive" apt-get install -yqq \
     git \
+    # bandaid fix for typing requirement
+    typing_extensions==4.2.0 \
     # Python lxml dependencies
     python3.7-dev \
     python3-opencv \


### PR DESCRIPTION
There was a problem building on develop (and other branches) due to a missing import. Added typing_extensions v4.2.0 to the gpu-dockerfile. Will run a test on dockerhub and then merge!