### PR TITLE
Add background removal to rodan jobs

### DIFF
--- a/rodan-main/code/rodan/jobs/background_removal/BgRemovalRodan.py
+++ b/rodan-main/code/rodan/jobs/background_removal/BgRemovalRodan.py
@@ -1,0 +1,81 @@
+import os
+
+from rodan.jobs.base import RodanTask
+from celery.utils.log import get_task_logger
+
+class BgRemoval(RodanTask):
+
+    name = 'Background Removal'
+    author = 'Wanyi Lin and Khoi Nguyen'
+    description = "Use Sauvola threshold to remove background"
+    logger = get_task_logger(__name__)
+
+    enabled = True
+    category = 'Background removal - remove image background'
+    interactive = False
+
+    input_port_types = [{
+        'name': 'Image',
+        'resource_types': lambda mime: mime.startswith('image/'),
+        'minimum': 1,
+        'maximum': 1
+    }]
+    output_port_types = [{
+        'name': 'RGB PNG image',
+        'resource_types': ['image/rgba+png'],
+        'minimum': 1,
+        'maximum': 1
+    }]
+
+    settings = {
+        'title': 'Remove Background',
+        'type': 'object',
+        'job_queue': 'GPU',
+
+        'properties': {
+            'Background Removal Method': {
+                'enum': ['Sauvola Algorithm', 'SAE Binarization Model'],
+                'default': 'Sauvola Algorithm',
+                'description': 'Choose one method for background removal'
+            },
+            'window_size': {
+                'type': 'integer',
+                'minimum': 1,
+                'default': 15
+            },
+            'k': {
+                'type': 'number',
+                'minimum': 0.0,
+                'default': 0.2
+            },
+            'contrast': {
+                'type': 'number',
+                'default': 127.0
+            },
+            'brightness': {
+                'type': 'number',
+                'default': 0.0
+            }
+        }
+    }
+
+    def run_my_task(self, inputs, settings, outputs):
+        from background_removal import background_removal_engine as Engine
+        from background_removal import LoaderWriter
+        from background_removal.binarize.binarize import run_binarize
+
+        load_image_path = inputs['Image'][0]['resource_path']
+        save_image_path = "{}.png".format(outputs['RGB PNG image'][0]['resource_path'])
+        if settings['Background Removal Method'] == 0:
+            image_bgr = LoaderWriter.load_image(load_image_path)
+            # Remove background here.
+            image_processed = Engine.remove_background(image_bgr, settings["window_size"], settings["k"], settings["contrast"], settings["brightness"])
+            LoaderWriter.write_image(save_image_path, image_processed)
+        else:
+            image_processed = run_binarize(load_image_path, save_image_path)
+
+        os.rename(save_image_path,outputs['RGB PNG image'][0]['resource_path'])
+        return True
+
+    def my_error_information(self, exc, traceback):
+        return

--- a/rodan-main/code/rodan/jobs/background_removal/__init__.py
+++ b/rodan-main/code/rodan/jobs/background_removal/__init__.py
@@ -1,0 +1,5 @@
+__version__ = "1.0.0"
+
+# Told rodan to load module here!
+from rodan.jobs import module_loader
+module_loader('rodan.jobs.background_removal.BgRemovalRodan')

--- a/rodan-main/code/rodan/jobs/background_removal/resource_types.yaml
+++ b/rodan-main/code/rodan/jobs/background_removal/resource_types.yaml
@@ -1,0 +1,15 @@
+- mimetype: image/rgb+png
+  description: RGB PNG image
+  extension: png
+- mimetype: image/rgb+jpg
+  description: JPG image file
+  extension: jpg
+- mimetype: image/rgba+png
+  description: PNG image file with alpha channel
+  extension: png
+- mimetype: image/greyscale+png
+  extension: png
+  description: Greyscale PNG image
+- mimetype: image/onebit+png
+  extension: png
+  description: One-bit (black and white) PNG image

--- a/rodan-main/code/rodan/jobs/register_all_jobs.py
+++ b/rodan-main/code/rodan/jobs/register_all_jobs.py
@@ -538,6 +538,14 @@ def register_gpu():
         import_name = "Paco Classifier"
         print(import_name + " failed to import with the following error:", exception.__class__.__name__)
 
+    # Register background_removal
+    try:
+        from rodan.jobs.background_removal.BgRemovalRodan import BgRemoval
+        app.register_task(BgRemoval())
+    except Exception as exception:
+        import_name = "Background Removal"
+        print(import_name + " failed to import with the following error:", exception.__class__.__name__)
+
 
 
 if __name__ == "__main__":

--- a/rodan-main/code/rodan/settings.py
+++ b/rodan-main/code/rodan/settings.py
@@ -159,7 +159,8 @@ RODAN_PYTHON3_JOBS = [
 RODAN_GPU_JOBS = [
     "rodan.jobs.Calvo_classifier",
     "rodan.jobs.text_alignment",
-    "rodan.jobs.Paco_classifier"
+    "rodan.jobs.Paco_classifier",
+    "rodan.jobs.background_removal"
 ]
 
 if RODAN_JOB_QUEUE == "None" or RODAN_JOB_QUEUE == "celery":

--- a/scripts/install_gpu_rodan_jobs
+++ b/scripts/install_gpu_rodan_jobs
@@ -26,5 +26,14 @@ cd /code/Rodan/rodan/jobs
 # Install Text Alignment
 $PIP install -r ./text_alignment/requirements.txt
 
+# Install Background Removal
+cd /
+git clone https://github.com/DDMAL/background_removal.git
+mv background_removal .background_removal
+cd .background_removal
+git fetch origin release
+git reset --hard origin/release
+which pip3 && $PIP install .
+
 cd /code/Rodan/rodan
 sed -i 's/#gpu //g' /code/Rodan/rodan/settings.py


### PR DESCRIPTION
### Add background removal's rodan job wrapper to rodan jobs, use `pip install .` to install background removal package ([`DDMAL/background_removal:release`](https://github.com/DDMAL/background_removal/tree/release)) inside `gpu-celery` container.

---

* Job Name: `Background Removal`
* Category: `Background removal - remove image background`
* Containers: `gpu-celery`
* Job Queue: `GPU`
* Input Port Type: `rgb+png`, `rgb+jpg`, `rgba+png`, `greyscale+png`, `onebit+png`
* Output Port Type: `rgba+png`
* Settings:
    * `Background Removal Method`: A drop down menu to select the method to do background removal. Support using [Sauvola Threshold](https://scikit-image.org/docs/stable/auto_examples/segmentation/plot_niblack_sauvola.html) (no neural network) and [Selectional Auto-Encoder (SAE) binarize](https://github.com/ajgallego/document-image-binarization) (with neural network)
    * `window_size`: The `window_size` for Sauvola Threshold, see docs for [`skimage`](https://scikit-image.org/docs/stable/api/skimage.filters.html#skimage.filters.threshold_sauvola)
    * `k`: The `k` for Sauvola Threshold, see docs for [`skimage`](https://scikit-image.org/docs/stable/api/skimage.filters.html#skimage.filters.threshold_sauvola)
    * `contrast`: adjust contrast before using Sauvola Threshold with `img = img * (contrast/127+1) - contrast + brightness`
    * `brightness`:  adjust brightness before using Sauvola Threshold with `img = img * (contrast/127+1) - contrast + brightness`

---
Note: If you're using `SAE binarize`, adjusting `window_size/k/contrast/brightness` has no effect.

