### PR TITLE
Add SAE binarization removal to rodan jobs

### DIFF
--- a/rodan-main/code/rodan/jobs/SAE_binarization/SAE_binarization.py
+++ b/rodan-main/code/rodan/jobs/SAE_binarization/SAE_binarization.py
@@ -1,0 +1,43 @@
+import os
+
+from rodan.jobs.base import RodanTask
+from celery.utils.log import get_task_logger
+
+class SAE_binarization(RodanTask):
+
+    name = 'SAE Binarization'
+    author = 'Wanyi Lin and Khoi Nguyen'
+    description = "Uses Neural Network Model to perform background removal"
+    logger = get_task_logger(__name__)
+
+    enabled = True
+    category = 'SAE Binarization - remove image background'
+    interactive = False
+
+    input_port_types = [{
+        'name': 'Image',
+        'resource_types': lambda mime: mime.startswith('image/'),
+        'minimum': 1,
+        'maximum': 1
+    }]
+    output_port_types = [{
+        'name': 'RGB PNG image',
+        'resource_types': ['image/rgba+png'],
+        'minimum': 1,
+        'maximum': 1
+    }]
+
+    settings = {'job_queue': 'GPU'}
+
+    def run_my_task(self, inputs, settings, outputs):
+        from SAE_binarization.binarize.binarize import run_binarize
+
+        load_image_path = inputs['Image'][0]['resource_path']
+        save_image_path = "{}.png".format(outputs['RGB PNG image'][0]['resource_path'])
+        image_processed = run_binarize(load_image_path, save_image_path)
+
+        os.rename(save_image_path,outputs['RGB PNG image'][0]['resource_path'])
+        return True
+
+    def my_error_information(self, exc, traceback):
+        return

--- a/rodan-main/code/rodan/jobs/SAE_binarization/__init__.py
+++ b/rodan-main/code/rodan/jobs/SAE_binarization/__init__.py
@@ -1,0 +1,5 @@
+__version__ = "1.0.0"
+
+# Told rodan to load module here!
+from rodan.jobs import module_loader
+module_loader('rodan.jobs.SAE_binarization.SAE_binarization')

--- a/rodan-main/code/rodan/jobs/SAE_binarization/resource_types.yaml
+++ b/rodan-main/code/rodan/jobs/SAE_binarization/resource_types.yaml
@@ -1,0 +1,15 @@
+- mimetype: image/rgb+png
+  description: RGB PNG image
+  extension: png
+- mimetype: image/rgb+jpg
+  description: JPG image file
+  extension: jpg
+- mimetype: image/rgba+png
+  description: PNG image file with alpha channel
+  extension: png
+- mimetype: image/greyscale+png
+  extension: png
+  description: Greyscale PNG image
+- mimetype: image/onebit+png
+  extension: png
+  description: One-bit (black and white) PNG image

--- a/rodan-main/code/rodan/jobs/register_all_jobs.py
+++ b/rodan-main/code/rodan/jobs/register_all_jobs.py
@@ -546,6 +546,14 @@ def register_gpu():
         import_name = "Background Removal"
         print(import_name + " failed to import with the following error:", exception.__class__.__name__)
 
+    # Register SAE binarization
+    try:
+        from rodan.jobs.SAE_binarization.SAE_binarization import SAE_binarization
+        app.register_task(SAE_binarization())
+    except Exception as exception:
+        import_name = "SAE binarization"
+        print(import_name + " failed to import with the following error:", exception.__class__.__name__)
+
 
 
 if __name__ == "__main__":

--- a/rodan-main/code/rodan/settings.py
+++ b/rodan-main/code/rodan/settings.py
@@ -160,7 +160,8 @@ RODAN_GPU_JOBS = [
     "rodan.jobs.Calvo_classifier",
     "rodan.jobs.text_alignment",
     "rodan.jobs.Paco_classifier",
-    "rodan.jobs.background_removal"
+    "rodan.jobs.background_removal",
+    "rodan.jobs.SAE_binarization"
 ]
 
 if RODAN_JOB_QUEUE == "None" or RODAN_JOB_QUEUE == "celery":

--- a/scripts/install_gpu_rodan_jobs
+++ b/scripts/install_gpu_rodan_jobs
@@ -35,5 +35,14 @@ git fetch origin release
 git reset --hard origin/release
 which pip3 && $PIP install .
 
+# Install SAE_binarization
+cd /
+git clone https://github.com/DDMAL/SAE_binarization.git
+mv SAE_binarization .SAE_binarization
+cd .SAE_binarization
+git fetch origin release
+git reset --hard origin/release
+which pip3 && $PIP install .
+
 cd /code/Rodan/rodan
 sed -i 's/#gpu //g' /code/Rodan/rodan/settings.py


### PR DESCRIPTION
### Add Selectional auto-encoder (SAE) binarization's rodan job wrapper to rodan jobs, use `pip install .` to install sae binarization package ([`DDMAL/SAE_binarization:release`](https://github.com/DDMAL/SAE_binarization/tree/release)) inside `gpu-celery` container.

---