### PR TITLE
Add empty output port to bgRemoval rodan wrapper, clone with tag

### DIFF
--- a/rodan-main/code/rodan/jobs/background_removal/BgRemovalRodan.py
+++ b/rodan-main/code/rodan/jobs/background_removal/BgRemovalRodan.py
@@ -21,9 +21,15 @@ class BgRemoval(RodanTask):
         'maximum': 1
     }]
     output_port_types = [{
-        'name': 'RGB PNG image',
+        'name': 'RGBA PNG image',
         'resource_types': ['image/rgba+png'],
         'minimum': 1,
+        'maximum': 1
+    },
+    {
+        'name': 'Empty Layer',
+        'resource_types': ['image/rgba+png'],
+        'minimum': 0,
         'maximum': 1
     }]
 
@@ -65,7 +71,7 @@ class BgRemoval(RodanTask):
         from background_removal.binarize.binarize import run_binarize
 
         load_image_path = inputs['Image'][0]['resource_path']
-        save_image_path = "{}.png".format(outputs['RGB PNG image'][0]['resource_path'])
+        save_image_path = "{}.png".format(outputs['RGBA PNG image'][0]['resource_path'])
         if settings['Background Removal Method'] == 0:
             image_bgr = LoaderWriter.load_image(load_image_path)
             # Remove background here.
@@ -74,7 +80,12 @@ class BgRemoval(RodanTask):
         else:
             image_processed = run_binarize(load_image_path, save_image_path)
 
-        os.rename(save_image_path,outputs['RGB PNG image'][0]['resource_path'])
+        os.rename(save_image_path,outputs['RGBA PNG image'][0]['resource_path'])
+        if 'Empty Layer' in outputs:
+            empty_layer = Engine.empty_layer(image_bgr)
+            empty_image_path = "{}.png".format(outputs['Empty Layer'][0]['resource_path'])
+            LoaderWriter.write_image(empty_image_path, empty_layer)
+            os.rename(empty_image_path, outputs['Empty Layer'][0]['resource_path'])
         return True
 
     def my_error_information(self, exc, traceback):

--- a/scripts/install_gpu_rodan_jobs
+++ b/scripts/install_gpu_rodan_jobs
@@ -28,11 +28,9 @@ $PIP install -r ./text_alignment/requirements.txt
 
 # Install Background Removal
 cd /
-git clone https://github.com/DDMAL/background_removal.git
+git clone -b v1.0.0 https://github.com/DDMAL/background_removal.git
 mv background_removal .background_removal
 cd .background_removal
-git fetch origin release
-git reset --hard origin/release
 which pip3 && $PIP install .
 
 # Install SAE_binarization


### PR DESCRIPTION
1. Add an optional empty output port to rodan job. This is the intput layer to pixel_wrapper.
2. git clone using tag v1.0.0