### PR TITLE
increase memory allocation for prod, staging

### DIFF
--- a/production.yml
+++ b/production.yml
@@ -44,10 +44,10 @@ services:
       resources:
         reservations:
           cpus: "1"
-          memory: 2G
+          memory: 4G
         limits:
           cpus: "1"
-          memory: 2G
+          memory: 4G
       restart_policy:
         condition: any
         delay: 5s

--- a/staging.yml
+++ b/staging.yml
@@ -44,10 +44,10 @@ services:
       resources:
         reservations:
           cpus: "1"
-          memory: 2G
+          memory: 4G
         limits:
           cpus: "1"
-          memory: 2G
+          memory: 4G
       restart_policy:
         condition: any
         delay: 5s


### PR DESCRIPTION
Changing the default memory allocation for `production.yml` and `staging.yml` to fix https://github.com/DDMAL/Rodan/issues/670, hopefully