### PR TITLE
add try except for pika import error

### DIFF
--- a/rodan-main/code/rodan/jobs/hpc_fast_trainer/hpc_fast_trainer.py
+++ b/rodan-main/code/rodan/jobs/hpc_fast_trainer/hpc_fast_trainer.py
@@ -6,8 +6,10 @@ from uuid import uuid4
 import base64
 import json
 import os
-import pika
-
+try:
+    import pika
+except ImportError:
+    pass
 
 class HPCFastTrainer(RodanTask):
     name = "Training model for Patchwise Analysis of Music Document - HPC"


### PR DESCRIPTION
this is similar to the gamera error when all jobs are moved to python3 along with their dependencies but rodan-main while register jobs look for the dependencies in python2 container. The try-except clause ignore the dependency import until it's actually running the job in python3 container