### PR TITLE
New production release for python 3!

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ REPLACE := perl -i -pe
 RODAN_PATH := ./rodan-main/code/rodan
 JOBS_PATH := $(RODAN_PATH)/jobs
 
-PROD_TAG := v2.0.2
+PROD_TAG := v2.0.4
 
 # Individual Commands
 

--- a/production.yml
+++ b/production.yml
@@ -3,7 +3,7 @@ version: "3.4"
 services:
 
   nginx:
-    image: "ddmal/nginx:v2.0.3"
+    image: "ddmal/nginx:v2.0.4"
     deploy:
       replicas: 1
       resources:
@@ -38,7 +38,7 @@ services:
       - "certbot:/etc/letsencrypt"
 
   rodan-main:
-    image: "ddmal/rodan-main:v2.0.3"
+    image: "ddmal/rodan-main:v2.0.4"
     deploy:
       replicas: 1
       resources:
@@ -74,7 +74,7 @@ services:
       - "resources:/rodan/data"
 
   celery:
-    image: "ddmal/rodan-main:v2.0.3"
+    image: "ddmal/rodan-main:v2.0.4"
     deploy:
       replicas: 1
       resources:
@@ -105,7 +105,7 @@ services:
       - "resources:/rodan/data"
 
   py3-celery:
-    image: "ddmal/rodan-python3-celery:v2.0.3"
+    image: "ddmal/rodan-python3-celery:v2.0.4"
     deploy:
       replicas: 1
       resources:
@@ -136,7 +136,7 @@ services:
       - "resources:/rodan/data"
 
   gpu-celery:
-    image: "ddmal/rodan-gpu-celery:v2.0.3"
+    image: "ddmal/rodan-gpu-celery:v2.0.4"
     deploy:
       replicas: 1
       resources:
@@ -192,7 +192,7 @@ services:
       TZ: America/Toronto
 
   postgres:
-    image: "ddmal/postgres-plpython:v2.0.3"
+    image: "ddmal/postgres-plpython:v2.0.4"
     deploy:
       replicas: 1
       endpoint_mode: dnsrr
@@ -246,7 +246,7 @@ services:
       - ./scripts/production.env
 
   hpc-rabbitmq:
-    image: "ddmal/hpc-rabbitmq:v2.0.3"
+    image: "ddmal/hpc-rabbitmq:v2.0.4"
     deploy:
       replicas: 1
       resources:

--- a/scripts/start
+++ b/scripts/start
@@ -4,7 +4,7 @@ set -o errexit # Exit immediately if a command exits with a non-zero status.
 set -o xtrace # Print commands and their arguments as they are executed.
 
 chmod -R a+rwx /rodan
-chmod -R a+rwx /var
+chmod a+rwx /var
 
 cd /code/Rodan
 runuser -u www-data -- yes | MIGRATE="True" python3 manage.py migrate --noinput

--- a/scripts/start-celery
+++ b/scripts/start-celery
@@ -3,7 +3,7 @@ set -o errexit # Exit immediately if a command exits with a non-zero status.
 set -o nounset # Treat unset variables as an error when substituting.
 set -o xtrace # Print commands and their arguments as they are executed.
 
-chmod -R a+rwx /var
+chmod a+rwx /var
 
 _term() { 
   echo "Caught SIGTERM signal!" 


### PR DESCRIPTION
Production officially works in python3!

Ended up creating a new branch to avoid all the unecessary back and forth commits but I'll document our work on here.
We had to fix the var permissions to make it not a recursive process. The var folder does however need to be read and writeable due to an error that pops up in text allignment.

Updating the database was a bit trickier. For starters, we needed to have both plpythonu (which defaults to python 2) and plpython3u in the postgres container which seemed counterinuitive. While our code works in plpython3, the database was looking for the plpython2 directory to try to update the old code. Then once the database was updated once, we could remove plpythonu from the postgres container and dockerfile.

The most recent problem we had was an import redis error that was coming from the publish_message function. This was a problem that only existed on production for some reason. Essentially, the publish_message wasn't being updated for some reason so it was running in plpythonu (which didn't have redis on it). Katie and I went in and manually edited it the function in there. 
My theory is that the order of the functions called by the post_migrate trigger in production was messing with this but I'm not fully sure.

Regardless things seem to work smoothly now and this shouldn't be a problem in the future.