### PR TITLE
Fix #752, Fix Server-Error-500 in Pixel

### DIFF
--- a/rodan-main/code/rodan/jobs/diva_generate_json.py
+++ b/rodan-main/code/rodan/jobs/diva_generate_json.py
@@ -160,20 +160,20 @@ class GenerateJson(object):
         # just tooooo sloooowww.
         f = open(fn, 'rb')
         d = f.read(100)
-        startHeader = d.find('ihdr')
+        startHeader = d.find(b'ihdr')
         hs = startHeader + 4
         ws = startHeader + 8
         height = (
-            ord(d[hs]) * 256 ** 3
-            + ord(d[hs + 1]) * 256 ** 2
-            + ord(d[hs + 2]) * 256
-            + ord(d[hs + 3])
+            d[hs] * 256 ** 3
+            + d[hs + 1] * 256 ** 2
+            + d[hs + 2] * 256
+            + d[hs + 3]
         )
         width = (
-            ord(d[ws]) * 256 ** 3
-            + ord(d[ws + 1]) * 256 ** 2
-            + ord(d[ws + 2]) * 256
-            + ord(d[ws + 3])
+            d[ws] * 256 ** 3
+            + d[ws + 1] * 256 ** 2
+            + d[ws + 2] * 256
+            + d[ws + 3]
         )
         f.close()
         return (width, height)


### PR DESCRIPTION
Resolve #752 
Resolve DDMAL/pixel_wrapper#53

In Rodan v2.0.4 (SHA:bdb65ce) pixel is seriously broken. Can't even open
small images and always get Server Error 500. This is because the
create_diva job failed after migrating all jobs into python3.

This commit makes create_diva work in py3 by fixing the find() function
and the way to decode image width/height from bytes.