### PR TITLE
Revert "Build off of master"

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -26,13 +26,13 @@ docker build \
   --no-cache \
   --build-arg BRANCHES="develop" \
   --build-arg VERSION=${RODAN_TAG} \
-  --tag ddmal/rodan-python3-celery:v2.0.4 \
+  --tag ddmal/rodan-python3-celery:nightly \
   --tag ddmal/rodan-python3-celery:${RODAN_TAG} \
   --file ./python3-celery/Dockerfile \
   .
 
 echo "[+] Pushing Python3-Celery"
-docker push ddmal/rodan-python3-celery:v2.0.4
+docker push ddmal/rodan-python3-celery:nightly
 
 echo "[+] Python3-Celery needs to be made and pushed before Rodan/Celery because the Rodan image uses the Python3 image as its base."
 
@@ -54,7 +54,7 @@ docker build \
   --build-arg BRANCHES="develop" \
   --build-arg VERSION=${RODAN_TAG} \
   --build-arg build_hash=${BUILD_HASH} \
-  --tag ddmal/rodan-main:v2.0.4 \
+  --tag ddmal/rodan-main:nightly \
   --tag ddmal/rodan-main:${RODAN_TAG} \
   --file ./rodan-main/Dockerfile \
   .
@@ -72,7 +72,7 @@ docker build \
   --no-cache \
   --build-arg BRANCHES="develop" \
   --build-arg VERSION=${RODAN_CLIENT_TAG} \
-  --tag ddmal/rodan-client:v2.0.4 \
+  --tag ddmal/rodan-client:nightly \
   --tag ddmal/rodan-client:${RODAN_CLIENT_TAG} \
   ./rodan-client
 
@@ -83,7 +83,7 @@ if [ -z `echo ${RODAN_TAG} | awk -F'-' '{print $3}'` ]; then
   docker push ddmal/rodan-main:${RODAN_TAG}
 fi
 
-docker push ddmal/rodan-main:v2.0.4
+docker push ddmal/rodan-main:nightly
 
 echo "[+] Pushing Rodan-Client"
 
@@ -92,7 +92,7 @@ if [ -z `echo ${RODAN_CLIENT_TAG} | awk -F'-' '{print $3}'` ]; then
   docker push ddmal/rodan-client:${RODAN_CLIENT_TAG}
 fi
 
-docker push ddmal/rodan-client:v2.0.4
+docker push ddmal/rodan-client:nightly
 
 ###############################################################################
 # Stage 3
@@ -104,7 +104,7 @@ docker build \
   --no-cache \
   --build-arg BRANCHES="develop" \
   --build-arg VERSION=${RODAN_TAG} \
-  --tag ddmal/rodan-gpu-celery:v2.0.4 \
+  --tag ddmal/rodan-gpu-celery:nightly \
   --tag ddmal/rodan-gpu-celery:${RODAN_TAG} \
   --file ./gpu-celery/Dockerfile \
   .
@@ -114,7 +114,7 @@ echo "[+] Building Postgres"
 docker build \
   --no-cache \
   --build-arg VERSION=${RODAN_DOCKER_TAG} \
-  --tag ddmal/postgres-plpython:v2.0.4 \
+  --tag ddmal/postgres-plpython:nightly \
   --tag ddmal/postgres-plpython:${RODAN_DOCKER_TAG} \
   --file ./postgres/Dockerfile \
   .
@@ -124,7 +124,7 @@ echo "[+] Building Nginx"
 docker build \
   --no-cache \
   --build-arg VERSION=${RODAN_DOCKER_TAG} \
-  --tag ddmal/nginx:v2.0.4 \
+  --tag ddmal/nginx:nightly \
   --tag ddmal/nginx:${RODAN_DOCKER_TAG} \
   ./nginx
 
@@ -133,7 +133,7 @@ echo "[+] Building HPC-RabbitMQ"
 docker build \
   --no-cache \
   --build-arg VERSION=${RODAN_DOCKER_TAG} \
-  --tag ddmal/hpc-rabbitmq:v2.0.4 \
+  --tag ddmal/hpc-rabbitmq:nightly \
   --tag ddmal/hpc-rabbitmq:${RODAN_DOCKER_TAG} \
   ./hpc-rabbitmq
 

--- a/hooks/push
+++ b/hooks/push
@@ -12,7 +12,7 @@ if [ -z `echo ${RODAN_TAG} | awk -F'-' '{print $3}'` ]; then
   docker push ddmal/rodan-python3-celery:${RODAN_TAG}
 fi
 
-docker push ddmal/rodan-python3-celery:v2.0.4
+docker push ddmal/rodan-python3-celery:nightly
 
 echo "[+] Pushing GPU-Celery"
 
@@ -20,7 +20,7 @@ if [ -z `echo ${RODAN_TAG} | awk -F'-' '{print $3}'` ]; then
   docker push ddmal/rodan-gpu-celery:${RODAN_TAG}
 fi
 
-docker push ddmal/rodan-gpu-celery:v2.0.4
+docker push ddmal/rodan-gpu-celery:nightly
 
 echo "[+] Pushing Postgres"
 
@@ -28,7 +28,7 @@ if [ -z `echo ${RODAN_DOCKER_TAG} | awk -F'-' '{print $3}'` ]; then
   docker push ddmal/postgres-plpython:${RODAN_DOCKER_TAG}
 fi
 
-docker push ddmal/postgres-plpython:v2.0.4
+docker push ddmal/postgres-plpython:nightly
 
 echo "[+] Pushing Nginx"
 
@@ -36,7 +36,7 @@ if [ -z `echo ${RODAN_DOCKER_TAG} | awk -F'-' '{print $3}'` ]; then
   docker push ddmal/nginx:${RODAN_DOCKER_TAG}
 fi
 
-docker push ddmal/nginx:v2.0.4
+docker push ddmal/nginx:nightly
 
 echo "[+] Pushing HPC-RabbitMQ"
 
@@ -44,4 +44,4 @@ if [ -z `echo ${RODAN_DOCKER_TAG} | awk -F'-' '{print $3}'` ]; then
   docker push ddmal/hpc-rabbitmq:${RODAN_DOCKER_TAG}
 fi
 
-docker push ddmal/hpc-rabbitmq:v2.0.4
+docker push ddmal/hpc-rabbitmq:nightly


### PR DESCRIPTION
Reverts DDMAL/Rodan#756

This isn't workable in the long run since the build hooks to make rodan-main pull from a `nightly` branch already. Going to find another way to do it.