### PR TITLE
Update paco classifier to v2.0.0

### DIFF
--- a/python3-celery/Dockerfile
+++ b/python3-celery/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add \
   yarn
 
 # Build Pixel
-RUN git clone --recurse-submodules -b "${BRANCH}" https://github.com/DDMAL/pixel_wrapper.git
+RUN git clone --recurse-submodules -b v2.0.0 https://github.com/DDMAL/pixel_wrapper.git
 WORKDIR /pixel_wrapper/
 RUN python3 activate_wrapper.py
 RUN npm install

--- a/rodan-main/code/rodan/jobs/Paco_classifier/fast_paco_trainer.py
+++ b/rodan-main/code/rodan/jobs/Paco_classifier/fast_paco_trainer.py
@@ -125,7 +125,7 @@ class FastPacoTrainer(RodanTask):
     def run_my_task(self, inputs, settings, outputs):
         from Paco_classifier import training_engine_sae as training
         from Paco_classifier.fast_trainer_lib import PacoTrainer
-        from Paco_classifier import input_settings_test
+        from Paco_classifier import preprocess
 
         oldouts = sys.stdout, sys.stderr
         if 'Log File' in outputs:
@@ -193,7 +193,7 @@ class FastPacoTrainer(RodanTask):
                     create_folder = False
 
             # SANITY CHECK
-            input_settings_test.pre_training_check(new_input, batch_size, patch_height, patch_width, number_samples_per_class)
+            layer_dict = preprocess.preprocess(new_input, batch_size, patch_height, patch_width, number_samples_per_class)
 
             rlevel = app.conf.CELERY_REDIRECT_STDOUTS_LEVEL
             app.log.redirect_stdouts_to_logger(logger, rlevel)
@@ -207,12 +207,10 @@ class FastPacoTrainer(RodanTask):
                 number_samples_per_class,
                 file_selection_mode,
                 sample_extraction_mode,
-                # Changed input to new_input for unzip
-                new_input,
+                layer_dict,
                 outputs,
-                # Add models input to Trainer
                 models,
-                patience=patience
+                patience
             )
             trainer.runTrainer()
 

--- a/rodan-main/code/rodan/jobs/Paco_classifier/fast_paco_trainer.py
+++ b/rodan-main/code/rodan/jobs/Paco_classifier/fast_paco_trainer.py
@@ -67,7 +67,7 @@ class FastPacoTrainer(RodanTask):
     }
 
     input_port_types = (
-        {'name': 'Samples Zip', 'minimum': 0, 'maximum': 1, 'resource_types': ['application/zip']},
+        {'name': 'Multi-Sample Zip', 'minimum': 0, 'maximum': 1, 'resource_types': ['application/zip']},
         {'name': 'Model 0', 'minimum': 0, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
         {'name': 'Model 1', 'minimum': 0, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
         {'name': 'Model 2', 'minimum': 0, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
@@ -102,7 +102,7 @@ class FastPacoTrainer(RodanTask):
     output_port_types = (
         # We did not go this route because it would be more difficult for the user to track layers
         # {'name': 'Adjustable models', 'minimum': 1, 'maximum': 10, 'resource_types': ['keras/model+hdf5']},
-        {'name': 'Samples Zip', 'minimum': 0, 'maximum': 1, 'resource_types': ['application/zip']},
+        {'name': 'Multi-Sample Zip', 'minimum': 0, 'maximum': 1, 'resource_types': ['application/zip']},
         {'name': 'Log File', 'minimum': 1, 'maximum': 1, 'resource_types': ['text/plain']},
         {'name': 'Model 0', 'minimum': 1, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
         {'name': 'Model 1', 'minimum': 1, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
@@ -152,9 +152,9 @@ class FastPacoTrainer(RodanTask):
             create_folder = True
             folder_num = 1
 
-            # Unzip Samples Zip to unzipping_folder
-            if 'Samples Zip' in inputs:
-                with zipfile.ZipFile(inputs['Samples Zip'][0]['resource_path'], 'r') as zip_ref:
+            # Unzip Multi-Sample Zip to unzipping_folder
+            if 'Multi-Sample Zip' in inputs:
+                with zipfile.ZipFile(inputs['Multi-Sample Zip'][0]['resource_path'], 'r') as zip_ref:
                     zip_ref.extractall('unzipping_folder')
                 
             # Count number of directories inside unzipping_folder
@@ -164,7 +164,7 @@ class FastPacoTrainer(RodanTask):
                 if 'Model' in ipt:
                     models[ipt] = inputs[ipt]
                 # Unzip other samples into unzipping_folder
-                elif ipt != 'Samples Zip':
+                elif ipt != 'Multi-Sample Zip':
                     dir_num += 1
                     with zipfile.ZipFile(inputs[ipt][0]['resource_path'], 'r') as zip_ref:
                         zip_ref.extractall('unzipping_folder/zip{}'.format(dir_num))
@@ -209,9 +209,9 @@ class FastPacoTrainer(RodanTask):
             )
             trainer.runTrainer()
 
-            # Create output port Samples Zip
-            if 'Samples Zip' in outputs:
-                with zipfile.ZipFile(outputs['Samples Zip'][0]['resource_path'], 'w') as zipObj:
+            # Create output port Multi-Sample Zip
+            if 'Multi-Sample Zip' in outputs:
+                with zipfile.ZipFile(outputs['Multi-Sample Zip'][0]['resource_path'], 'w') as zipObj:
                     # Iterate over all the files in directory
                     for folder in os.listdir('unzipping_folder'):
                         for f in os.listdir(os.path.join('unzipping_folder', folder)):

--- a/rodan-main/code/rodan/jobs/Paco_classifier/fast_paco_trainer.py
+++ b/rodan-main/code/rodan/jobs/Paco_classifier/fast_paco_trainer.py
@@ -67,7 +67,13 @@ class FastPacoTrainer(RodanTask):
     }
 
     input_port_types = (
-        {'name': 'Sample 1', 'minimum': 1, 'maximum': 1, 'resource_types': ['application/zip']},
+        {'name': 'Samples Zip', 'minimum': 0, 'maximum': 1, 'resource_types': ['application/zip']},
+        {'name': 'Model 0', 'minimum': 0, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Model 1', 'minimum': 0, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Model 2', 'minimum': 0, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Model 3', 'minimum': 0, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Model 4', 'minimum': 0, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Sample 1', 'minimum': 0, 'maximum': 1, 'resource_types': ['application/zip']},
         {'name': 'Sample 2', 'minimum': 0, 'maximum': 1, 'resource_types': ['application/zip']},
         # We did not go this route because it would be more difficult for the user to track layers
         # {'name': 'rgba PNG - Layers', 'minimum': 1, 'maximum': 10, 'resource_types': ['image/rgba+png']},
@@ -89,11 +95,14 @@ class FastPacoTrainer(RodanTask):
         {'name': 'Sample 18', 'minimum': 0, 'maximum': 1, 'resource_types': ['application/zip']},
         {'name': 'Sample 19', 'minimum': 0, 'maximum': 1, 'resource_types': ['application/zip']},
         {'name': 'Sample 20', 'minimum': 0, 'maximum': 1, 'resource_types': ['application/zip']},
+        # We did not go this route because it would be more difficult for the user to track layers
+        # {'name': 'rgba PNG - Layers', 'minimum': 1, 'maximum': 10, 'resource_types': ['image/rgba+png']},
     )
 
     output_port_types = (
         # We did not go this route because it would be more difficult for the user to track layers
         # {'name': 'Adjustable models', 'minimum': 1, 'maximum': 10, 'resource_types': ['keras/model+hdf5']},
+        {'name': 'Samples Zip', 'minimum': 0, 'maximum': 1, 'resource_types': ['application/zip']},
         {'name': 'Log File', 'minimum': 1, 'maximum': 1, 'resource_types': ['text/plain']},
         {'name': 'Model 0', 'minimum': 1, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
         {'name': 'Model 1', 'minimum': 1, 'maximum': 1, 'resource_types': ['keras/model+hdf5']},
@@ -134,29 +143,50 @@ class FastPacoTrainer(RodanTask):
             sample_extraction_mode = training.SampleExtractionMode.RANDOM
             #------------------------------------------------------------
 
-            # Unzip zip files into dictionary of images
+            # Initialize
             if os.path.exists('unzipping_folder'):
                 rmtree('unzipping_folder')
             os.mkdir('unzipping_folder')
             new_input = {}
+            models = {}
             create_folder = True
             folder_num = 1
+
+            # Unzip Samples Zip to unzipping_folder
+            if 'Samples Zip' in inputs:
+                with zipfile.ZipFile(inputs['Samples Zip'][0]['resource_path'], 'r') as zip_ref:
+                    zip_ref.extractall('unzipping_folder')
+                
+            # Count number of directories inside unzipping_folder
+            dir_num = len(next(os.walk('unzipping_folder'))[1])
             for ipt in inputs:
-                dir_path = 'unzipping_folder/{}'.format(folder_num)
-                folder_num += 1
-                with zipfile.ZipFile(inputs[ipt][0]['resource_path'], 'r') as zip_ref:
-                    zip_ref.extractall(dir_path)
+                # Add models to model dictionary
+                if 'Model' in ipt:
+                    models[ipt] = inputs[ipt]
+                # Unzip other samples into unzipping_folder
+                elif ipt != 'Samples Zip':
+                    dir_num += 1
+                    with zipfile.ZipFile(inputs[ipt][0]['resource_path'], 'r') as zip_ref:
+                        zip_ref.extractall('unzipping_folder/zip{}'.format(dir_num))
+
+            # Add unzipped samples from above to dictionary of layers
+            for folder in os.listdir('unzipping_folder'):
+                dir_path = os.path.join('unzipping_folder', folder)
                 full_path = os.path.join(os.getcwd(), dir_path)
-                for f in os.listdir(dir_path):
-                    if os.path.isfile(os.path.join(dir_path, f)):
-                        layer_name = f.split(".")[0]
-                        if create_folder:
-                            new_input[layer_name] = []
-                        new_input[layer_name].append({'resource_path': os.path.join(full_path, f)})
-                create_folder = False
+                if os.path.isdir(dir_path):
+                    # Check if user inputs more models than layers
+                    num_layers = (len([name for name in os.listdir(dir_path) if os.path.isfile(os.path.join(dir_path, name))]) - 2)
+                    if num_layers < len(models):
+                        raise Exception('Number of models ({}) exceeds number of layers ({})'.format(len(models), num_layers))
+                    for f in os.listdir(dir_path):
+                        if os.path.isfile(os.path.join(dir_path, f)):
+                            layer_name = f.split(".")[0]
+                            if create_folder:
+                                new_input[layer_name] = []
+                            new_input[layer_name].append({'resource_path': os.path.join(full_path, f)})
+                    create_folder = False
 
             # SANITY CHECK
-            # logger.info(new_input)
             input_settings_test.pre_training_check(new_input, batch_size, patch_height, patch_width, number_samples_per_class)
 
             rlevel = app.conf.CELERY_REDIRECT_STDOUTS_LEVEL
@@ -171,11 +201,23 @@ class FastPacoTrainer(RodanTask):
                 number_samples_per_class,
                 file_selection_mode,
                 sample_extraction_mode,
-                # CHANGED HERE FOR UNZIP
+                # Changed input to new_input for unzip
                 new_input,
                 outputs,
+                # Add models input to Trainer
+                models
             )
             trainer.runTrainer()
+
+            # Create output port Samples Zip
+            if 'Samples Zip' in outputs:
+                with zipfile.ZipFile(outputs['Samples Zip'][0]['resource_path'], 'w') as zipObj:
+                    # Iterate over all the files in directory
+                    for folder in os.listdir('unzipping_folder'):
+                        for f in os.listdir(os.path.join('unzipping_folder', folder)):
+                            sub_path = os.path.join(folder, f)
+                            full_path = os.path.join('unzipping_folder', sub_path)
+                            zipObj.write(full_path, sub_path)
 
             # REMOVE UNZIP FOLDER
             if os.path.exists('unzipping_folder'):

--- a/rodan-main/code/rodan/jobs/Paco_classifier/fast_paco_trainer.py
+++ b/rodan-main/code/rodan/jobs/Paco_classifier/fast_paco_trainer.py
@@ -52,6 +52,11 @@ class FastPacoTrainer(RodanTask):
                 'minimum': 1,
                 'default': 1000
             },            
+            'Patience': {
+                'type': 'integer',
+                'minimum': 0,
+                'default': 15
+            },
             'Patch height': {
                 'type': 'integer',
                 'minimum': 32,
@@ -136,6 +141,7 @@ class FastPacoTrainer(RodanTask):
             patch_width = settings['Patch width']
             max_number_of_epochs = settings['Maximum number of training epochs']
             number_samples_per_class = settings['Maximum number of samples per label']
+            patience = settings["Patience"]
 
             #------------------------------------------------------------
             #TODO Include the training options in the configuration data
@@ -205,7 +211,8 @@ class FastPacoTrainer(RodanTask):
                 new_input,
                 outputs,
                 # Add models input to Trainer
-                models
+                models,
+                patience=patience
             )
             trainer.runTrainer()
 

--- a/scripts/install_gpu_rodan_jobs
+++ b/scripts/install_gpu_rodan_jobs
@@ -27,21 +27,21 @@ $PIP install -r ./text_alignment/requirements.txt
 
 # Install Background Removal
 cd /
-git clone -b v1.1.0-py3-rodan https://github.com/DDMAL/background_removal.git
+git clone -b v1.1.0 https://github.com/DDMAL/background_removal.git
 mv background_removal .background_removal
 cd .background_removal
 which pip3 && $PIP install .
  
 # Install SAE_binarization
 cd /
-git clone -b v1.1.0-py3-rodan https://github.com/DDMAL/SAE_binarization.git
+git clone -b v1.1.0 https://github.com/DDMAL/SAE_binarization.git
 mv SAE_binarization .SAE_binarization
 cd .SAE_binarization
 which pip3 && $PIP install .
 
 # Install Paco classifier
 cd /
-git clone -b v1.1.0-py3-rodan --depth 1 https://github.com/DDMAL/Paco_classifier.git
+git clone -b v2.0.0 --depth 1 https://github.com/DDMAL/Paco_classifier.git
 mv Paco_classifier .Paco_classifier
 cd .Paco_classifier
 which pip3 && $PIP install .

--- a/staging.yml
+++ b/staging.yml
@@ -148,10 +148,10 @@ services:
       resources:
         limits:
           cpus: '2'
-          memory: 4G
+          memory: 8G
         reservations:
           cpus: '2'
-          memory: 4G
+          memory: 8G
       restart_policy:
         condition: any
         delay: 5s


### PR DESCRIPTION
1. In `SAE_binarization`, `background_removal`, and `paco_classifier`, downgrade their python3 requirement from `3.7.5` to `3.7.3`. This is to let them go along with Rodan using python3.
2. In `paco_classifier`, support:
- using a large zip file containing tiny zip files as the training data
- let users decide the `patience` parameter
- optimized `v.2.0.0` paco, which requires less training time
3. Increase the RAM size in `gpu-celery`  container
4. Update pixel tag