### PR TITLE
Fix #668, fetch logs from containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,6 +247,18 @@ remote_jobs: $(JOBS_PATH)/pixel_wrapper/package.json $(JOBS_PATH)/neon_wrapper/s
 	@cd $(RODAN_PATH); $(REPLACE) "s/#py3 //g" ./settings.py
 	@cd $(RODAN_PATH); $(REPLACE) "s/#gpu //g" ./settings.py
 
+gpu-celery_log:
+	@docker exec $$(docker ps -f name=rodan_gpu-celery --format "{{.ID}}") tail -f /code/Rodan/rodan-celery-GPU.log
+
+py3-celery_log:
+	@docker exec $$(docker ps -f name=rodan_py3-celery --format "{{.ID}}") tail -f /code/Rodan/rodan-celery-Python3.log
+
+celery_log:
+	@docker exec $$(docker ps -f name=rodan_celery --format "{{.ID}}") tail -f /code/Rodan/rodan-celery-celery.log
+
+rodan-main_log:
+	@docker exec $$(docker ps -f name=rodan_rodan-main --format "{{.ID}}") tail -f /code/Rodan/rodan.log
+
 # Command Groups
 reset: stop clean pull run
 clean_reset: stop clean build run


### PR DESCRIPTION
Resolve #668 
1. `make gpu-celery_log` to fetch `rodan-celery-GPU.log` from `rodan_gpu-celery` container.
2. `make py3-celery_log` to fetch `rodan-celery-Python3.log` from `rodan_py3-celery` container.
3. `make celery_log` to fetch `rodan-celery-celery.log` from `rodan_celery` container.
4. `make rodan-main_log` to fetch `rodan.log` from `rodan_rodan-main` container.