### PR TITLE
Fix #764, Downgrade gamera container to py37

### DIFF
--- a/python3-celery/Dockerfile
+++ b/python3-celery/Dockerfile
@@ -26,7 +26,7 @@ RUN yarn install
 RUN yarn build
 
 # Make Gamera files accessible to the main container.
-FROM ddmal/gamera4 AS gamera
+FROM ddmal/gamera4:v1.0.1 AS gamera
 
 # This release is based on Debian 11 "Bullseye"
 FROM python:3.7-slim


### PR DESCRIPTION
Resolves #764 
load_png and load_tiff are not working because of the missing `_png_support.cpython-37m-x86_64-linux-gnu.so` and `_tiff_support.cpython-37m-x86_64-linux-gnu.so` in `ddmal/rodan-python3-celery`. But `_png_support.cpython-38m-x86_64-linux-gnu.so` and `_tiff_support.cpython-38m-x86_64-linux-gnu.so` do exist in `ddmal/gamera4:latest`.  Things went wrong when building `rodan-python3-celery` (py3.7) from `ddmal/gamera` (py3.8).


This PR solves this issue by downgrading the python version in `ddmal/gamera4` to 3.7 to solve this issue. Changes in this PR:
1. Downgrade `ddmal/gamera4`'s python3 version to 3.7. See [ddmal/gamera4-rodan](https://github.com/DDMAL/gamera4-rodan/commit/3ef2a48029b02f588ec84aa20849a1038977f0e1).
2. Use `ddmal/gamera4:v1.0.1`tag from docker hub. This is built from the `v1.0.1` tag in [ddmal/gamera4-rodan](https://github.com/DDMAL/gamera4-rodan/releases/tag/v1.0.1)
3. Build `ddmal/gamera4:v1.0.1` from the correct commit SHA (`76608f6` according to [this line](https://github.com/DDMAL/Rodan/blob/master/scripts/install_python3_rodan_jobs#L78)). `gamera` at this commit is currently working on production. Before this PR `ddmal/gamera4:v1.0.1` was built from an older commit (`c7e2f84` according to [this line](https://github.com/DDMAL/gamera4-rodan/commit/9f5d98778b8f615edd14ca5edef75896b92b10b7#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R17))

----
https://user-images.githubusercontent.com/25975988/188719726-48d0e49b-16a8-47da-aabc-3d84e0b5de6f.mov


