### PR TITLE
Fix #772, Remove multiple descriptions

### DIFF
--- a/python3-celery/Dockerfile
+++ b/python3-celery/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add \
   yarn
 
 # Build Pixel
-RUN git clone --recurse-submodules -b v2.0.0 https://github.com/DDMAL/pixel_wrapper.git
+RUN git clone --recurse-submodules -b v2.0.1 https://github.com/DDMAL/pixel_wrapper.git
 WORKDIR /pixel_wrapper/
 RUN python3 activate_wrapper.py
 RUN npm install

--- a/rodan-main/code/rodan/jobs/Paco_classifier/resource_types.yaml
+++ b/rodan-main/code/rodan/jobs/Paco_classifier/resource_types.yaml
@@ -11,5 +11,5 @@
   description: Trained network from Keras framework
   extension: hdf5
 - mimetype: application/zip
-  description: Zip file
+  description: Package
   extension: zip

--- a/rodan-main/code/rodan/jobs/mei2vol_wrapper/resource_types.yaml
+++ b/rodan-main/code/rodan/jobs/mei2vol_wrapper/resource_types.yaml
@@ -3,4 +3,4 @@
   description: Music Encoding Initiative
 - mimetype: text/plain
   extension: txt
-  description: volpiano txt file
+  description: Plain text


### PR DESCRIPTION
Resolves #772 
Change descriptions in the `resource_types.yaml` in the these jobs: `Paco_classifier`, `mei2vol_wrapper`, and `pixel_wrapper`, to remove the message:
```
Multiple descriptions found for <type>: 
    #1: <description 1>
    #2: <description 2>
    ...
Choose a description (#1, #2, ...) or enter yours: ...
```

These messages show up when using `MIGRATE=True python3 manage.py migrate --noinput` or `./manage.py test`