### PR TITLE
Fix #782, Restrict importlib version

### DIFF
--- a/rodan-main/code/requirements.txt
+++ b/rodan-main/code/requirements.txt
@@ -38,6 +38,7 @@ PyYAML==5.4
 redis==2.10.3
 uWSGI==2.0.18
 Werkzeug==1.0.1
+importlib-metadata==4.12.0
 
 # text_alignment
 #numpy==1.17.3; python_version > "3.4"


### PR DESCRIPTION
Resolves #782 
The v5.0.0 importlib-metadata causes import error in celery. Downgrade its version to v4.12.0