### PR TITLE
Fix #769, Set concurrency to 10 in py3-celery

### DIFF
--- a/production.yml
+++ b/production.yml
@@ -110,11 +110,11 @@ services:
       replicas: 1
       resources:
         reservations:
-          cpus: "1"
-          memory: 2G
+          cpus: "2"
+          memory: 8G
         limits:
-          cpus: "1"
-          memory: 2G
+          cpus: "2"
+          memory: 8G
       restart_policy:
         condition: any
         delay: 5s

--- a/python3-celery/Dockerfile
+++ b/python3-celery/Dockerfile
@@ -75,7 +75,7 @@ RUN python3 setup.py install
 # Temporary fix for OpenCV until https://github.com/DDMAL/Rodan/issues/639 is resolved.
 RUN pip install opencv-python==4.6.0.66
 
-# Change the concurency for python3 jobs (Calvo)
-RUN sed -i "s/=10/=1/g" /run/start-celery
+# Change the concurency for python3 jobs (Calvo) => Calvo is in gpu-celery not here.
+#RUN sed -i "s/=10/=1/g" /run/start-celery
 
 ENTRYPOINT ["/run/start-celery"]

--- a/staging.yml
+++ b/staging.yml
@@ -44,10 +44,10 @@ services:
       resources:
         reservations:
           cpus: "1"
-          memory: 8G
+          memory: 4G
         limits:
           cpus: "1"
-          memory: 8G
+          memory: 4G
       restart_policy:
         condition: any
         delay: 5s
@@ -116,11 +116,11 @@ services:
       replicas: 1
       resources:
         reservations:
-          cpus: "1"
-          memory: 2G
+          cpus: "2"
+          memory: 8G
         limits:
-          cpus: "1"
-          memory: 2G
+          cpus: "2"
+          memory: 8G
       restart_policy:
         condition: any
         delay: 5s


### PR DESCRIPTION
GPU-related jobs are not in py3-celery container. Try to increase the concurrency to run multiple py3 jobs parallelly. Increase memory or else py3-celery container will be stopped by oom_reaper.