### PR TITLE
Fix #787, Fix permission denied issue in nginx

### DIFF
--- a/rodan-main/code/rodan/settings.py
+++ b/rodan-main/code/rodan/settings.py
@@ -359,6 +359,7 @@ MIDDLEWARE_CLASSES = [
     "django.contrib.auth.middleware.SessionAuthenticationMiddleware",
 ]
 FILE_UPLOAD_HANDLERS = ["django.core.files.uploadhandler.TemporaryFileUploadHandler"]
+FILE_UPLOAD_PERMISSIONS =  0o644
 DATA_UPLOAD_MAX_MEMORY_SIZE = 262144000
 FILE_UPLOAD_MAX_MEMORY_SIZE = 104857600
 # REST framework


### PR DESCRIPTION
Resolves #787 

The permission for original_file (the original image) is 600 and the owner is root. This causes permission denied/403 forbidden error when pixel_wrapper tries to read the input layer and triggers nginx to read the origina_file as www-data user. This violates the permission and causes the issue.

Solution: Since running nginx subprocess as root is risky, this commit sets the uploaded file permission to 644 so both root and www-data can read the file.