### PR TITLE
Fix text alignment 

### DIFF
--- a/rodan-main/code/rodan/jobs/text_alignment/align_to_ocr.py
+++ b/rodan-main/code/rodan/jobs/text_alignment/align_to_ocr.py
@@ -77,11 +77,15 @@ def process(raw_image,
     image, eroded, angle = preproc.preprocess_images(raw_image)
     cc_strips, lines_peak_locs, _ = preproc.identify_text_lines(eroded)
 
+    assert len(cc_strips) > 0, "Fatal error: No text strips were found on the given page."
+
     # -- PERFORM OCR WITH CALAMARI --
     all_chars = existing_ocr
     if not all_chars:
         all_chars = perform_ocr.recognize_text_strips(image, cc_strips, ocr_model_name, verbose)
     all_chars = perform_ocr.handle_abbreviations(all_chars)
+
+    assert len(all_chars) > 0, "Fatal error: No characters were found in the OCR of the given page."
 
     # -- PERFORM AND PARSE ALIGNMENT --
     # get full ocr transcript as CharBoxes
@@ -220,21 +224,6 @@ if __name__ == '__main__':
     manuscript = 'salzinnes'
     f_inds = ['040r', '142v', '087r', '132v']
     ocr_model = 'gothic_salzinnes_2021'
-
-    # text_func = pcc.filename_to_text_func('./csv/einsiedeln_123606.csv')
-    # manuscript = 'einsiedeln'
-    # f_inds = range(0, 11)
-    # ocr_model = './salzinnes_model-00054500.pyrnn.gz'
-
-    # text_func = pcc.filename_to_text_func('./csv/stgall390_123717.csv')
-    # manuscript = 'stgall390'
-    # f_inds = ['022', '023', '024', '025', '007']
-    # ocr_model = 'stgall2-00017000.pyrnn.gz'
-
-    # text_func = pcc.filename_to_text_func('./csv/stgall388_123750.csv')
-    # manuscript = 'stgall388'
-    # f_inds = ['028', '029', '030', '031', '032']
-    # ocr_model = 'stgall3-00017000.pyrnn.gz'
 
     for ind in f_inds:
 

--- a/rodan-main/code/rodan/jobs/text_alignment/image_preprocessing.py
+++ b/rodan-main/code/rodan/jobs/text_alignment/image_preprocessing.py
@@ -168,7 +168,7 @@ def preprocess_images(input_image, soften=soften_amt, fill_holes=fill_holes):
 
     # get the otsu threshold after running a flood fill on the corners, so that those huge clumps of
     # dark pixels don't mess up the statistics too much (we only care about text!)
-    thresh = threshold_otsu(fill_corners(gray_img, fill_value=255, thresh=25, tol=25, fill_below_thresh=True))
+    thresh = threshold_otsu(fill_corners(gray_img, fill_value=255, thresh=5, tol=1, fill_below_thresh=True))
 
     # n.b. here we are setting black pixels from the original image to have a value of 1 (effectively inverting
     # what you would get from a normal binarization, because the math gets easier this way)

--- a/rodan-main/code/rodan/jobs/text_alignment/perform_ocr.py
+++ b/rodan-main/code/rodan/jobs/text_alignment/perform_ocr.py
@@ -103,10 +103,19 @@ def recognize_text_strips(img, line_strips, ocr_model_name, verbose=False):
 
         r = results[i]
         chars = list(r.outputs[1].sentence)
+
+        # skip this text strip if no characters were found in it
+        if len(chars) == 0:
+            continue
+
         global_starts = [x.global_start for x in r.outputs[1].positions]
 
-        # to find width of final character, append median char width to end of line
-        med_char_width = int(np.median(np.diff(global_starts)))
+        # to find width of final character, append median char width to end of line.
+        # double-check to make sure there is more than one character found in the line.
+        if len(global_starts) <= 1:
+            med_char_width = 1
+        else:
+            med_char_width = int(np.median(np.diff(global_starts)))
         global_starts = global_starts + [med_char_width + global_starts[-1]]
 
         res_line = []


### PR DESCRIPTION
Think this addresses https://github.com/DDMAL/Rodan/issues/779 by tweaking how the black background removal step works so that it doesn't flood-fill the entire manuscript with white occasionally - added sanity checks to several steps in the process, just to make sure it doesn't crash (unless it has to, and then it provides a better error message).