### PR TITLE
Fix #796, Increase RAM in celery and py3-celery container

### DIFF
--- a/production.yml
+++ b/production.yml
@@ -80,10 +80,10 @@ services:
       resources:
         reservations:
           cpus: "1"
-          memory: 4G
+          memory: 12G
         limits:
           cpus: "1"
-          memory: 4G
+          memory: 12G
       restart_policy:
         condition: any
         delay: 5s
@@ -111,10 +111,10 @@ services:
       resources:
         reservations:
           cpus: "2"
-          memory: 8G
+          memory: 12G
         limits:
           cpus: "2"
-          memory: 8G
+          memory: 12G
       restart_policy:
         condition: any
         delay: 5s

--- a/staging.yml
+++ b/staging.yml
@@ -82,10 +82,10 @@ services:
       resources:
         reservations:
           cpus: "1"
-          memory: 4G
+          memory: 12G
         limits:
           cpus: "1"
-          memory: 4G
+          memory: 12G
       restart_policy:
         condition: any
         delay: 5s
@@ -117,10 +117,10 @@ services:
       resources:
         reservations:
           cpus: "2"
-          memory: 8G
+          memory: 12G
         limits:
           cpus: "2"
-          memory: 8G
+          memory: 12G
       restart_policy:
         condition: any
         delay: 5s


### PR DESCRIPTION
Resolves #796 

Since the concurrency in celery and py3-celery is 10, there will be at least 10 large images using RAM at the same time. We need more RAM to do so.