### PR TITLE
Fix #797, loose health check condition on staging

### DIFF
--- a/python3-celery/Dockerfile
+++ b/python3-celery/Dockerfile
@@ -75,7 +75,7 @@ RUN python3 setup.py install
 # Temporary fix for OpenCV until https://github.com/DDMAL/Rodan/issues/639 is resolved.
 RUN pip install opencv-python==4.6.0.66
 
-# Change the concurency for python3 jobs (Calvo) => Calvo is in gpu-celery not here.
-#RUN sed -i "s/=10/=1/g" /run/start-celery
+# Change the concurency for python3 jobs
+RUN sed -i "s/=10/=6/g" /run/start-celery
 
 ENTRYPOINT ["/run/start-celery"]

--- a/staging.yml
+++ b/staging.yml
@@ -56,9 +56,9 @@ services:
     # https://github.com/DDMAL/rodan-docker/issues/61
     healthcheck:
       test: ["CMD-SHELL", "/usr/bin/curl -H 'User-Agent: docker-healthcheck' http://localhost:8000/api/?format=json || exit 1"]
-      interval: "10s"
-      timeout: "5s"
-      retries: 2
+      interval: "30s"
+      timeout: "30s"
+      retries: 5
       start_period: "2m"
     command: /run/start
     environment:
@@ -81,25 +81,25 @@ services:
       replicas: 1
       resources:
         reservations:
-          cpus: "1"
+          cpus: "2"
           memory: 12G
         limits:
-          cpus: "1"
+          cpus: "2"
           memory: 12G
       restart_policy:
         condition: any
         delay: 5s
         window: 30s
     healthcheck:
-      test: ["CMD", "celery", "inspect", "ping", "-A", "rodan", "--workdir", "/code/Rodan", "-d", "celery@celery"]
+      test: ["CMD", "celery", "inspect", "ping", "-A", "rodan", "--workdir", "/code/Rodan", "-d", "celery@celery", "-t", "30"]
       # first run interval seconds after the container is started, and then again interval seconds after each previous
       interval: "30s"
       # How long to wait for the healthcheck to succeed
-      timeout: "10s"
+      timeout: "30s"
       # Ignore failures during the start_period
       start_period: "1m"
       # accept 3 consecutive failures before 
-      retries: 3
+      retries: 5
     command: /run/start-celery
     environment:
       TZ: America/Toronto
@@ -126,10 +126,10 @@ services:
         delay: 5s
         window: 30s
     healthcheck:
-      test: ["CMD", "celery", "inspect", "ping", "-A", "rodan", "--workdir", "/code/Rodan", "-d", "celery@Python3"]
+      test: ["CMD", "celery", "inspect", "ping", "-A", "rodan", "--workdir", "/code/Rodan", "-d", "celery@Python3", "-t", "30"]
       interval: "30s"
-      timeout: "10s"
-      retries: 3
+      timeout: "30s"
+      retries: 5
     command: /run/start-celery
     environment:
       TZ: America/Toronto
@@ -147,20 +147,20 @@ services:
       replicas: 1
       resources:
         limits:
-          cpus: '2'
+          cpus: '1'
           memory: 8G
         reservations:
-          cpus: '2'
+          cpus: '1'
           memory: 8G
       restart_policy:
         condition: any
         delay: 5s
         window: 30s
     healthcheck:
-      test: ["CMD", "celery", "inspect", "ping", "-A", "rodan", "--workdir", "/code/Rodan", "-d", "celery@GPU"]
+      test: ["CMD", "celery", "inspect", "ping", "-A", "rodan", "--workdir", "/code/Rodan", "-d", "celery@GPU", "-t", "30"]
       interval: "30s"
-      timeout: "10s"
-      retries: 3
+      timeout: "30s"
+      retries: 5
     command: /run/start-celery
     environment:
       TZ: America/Toronto


### PR DESCRIPTION
Resolves #797 

- Loose the health-check condition in rodan-main/celery/py3-celery or else they are shut down from time to time and cause hanging jobs.
- Reduce the concurrency in celery/py3-celery
- Increase cpus in celery, decrease cpuys in gpu-celery