### PR TITLE
Fix #797, loose health check condition on production

### DIFF
--- a/production.yml
+++ b/production.yml
@@ -54,9 +54,9 @@ services:
         window: 30s
     healthcheck:
       test: ["CMD-SHELL", "/usr/bin/curl -H 'User-Agent: docker-healthcheck' http://localhost:8000/api/?format=json || exit 1"]
-      interval: "10s"
-      timeout: "5s"
-      retries: 2
+      interval: "30s"
+      timeout: "30s"
+      retries: 5
       start_period: "2m"
     command: /run/start
     environment:
@@ -79,21 +79,21 @@ services:
       replicas: 1
       resources:
         reservations:
-          cpus: "1"
+          cpus: "6"
           memory: 12G
         limits:
-          cpus: "1"
+          cpus: "6"
           memory: 12G
       restart_policy:
         condition: any
         delay: 5s
         window: 30s
     healthcheck:
-      test: ["CMD", "celery", "inspect", "ping", "-A", "rodan", "--workdir", "/code/Rodan", "-d", "celery@celery"]
+      test: ["CMD", "celery", "inspect", "ping", "-A", "rodan", "--workdir", "/code/Rodan", "-d", "celery@celery", "-t", "30"]
       interval: "30s"
-      timeout: "10s"
+      timeout: "30s"
       start_period: "1m"
-      retries: 3
+      retries: 5
     command: /run/start-celery
     environment:
       TZ: America/Toronto
@@ -110,20 +110,20 @@ services:
       replicas: 1
       resources:
         reservations:
-          cpus: "2"
+          cpus: "6"
           memory: 12G
         limits:
-          cpus: "2"
+          cpus: "6"
           memory: 12G
       restart_policy:
         condition: any
         delay: 5s
         window: 30s
     healthcheck:
-      test: ["CMD", "celery", "inspect", "ping", "-A", "rodan", "--workdir", "/code/Rodan", "-d", "celery@Python3"]
+      test: ["CMD", "celery", "inspect", "ping", "-A", "rodan", "--workdir", "/code/Rodan", "-d", "celery@Python3", "-t", "30"]
       interval: "30s"
-      timeout: "10s"
-      retries: 3
+      timeout: "30s"
+      retries: 5
     command: /run/start-celery
     environment:
       TZ: America/Toronto
@@ -141,10 +141,10 @@ services:
       replicas: 1
       resources:
         reservations:
-          cpus: "6"
+          cpus: "2"
           memory: 45G
         limits:
-          cpus: "6"
+          cpus: "2"
           memory: 45G
       restart_policy:
         condition: any
@@ -154,10 +154,10 @@ services:
         constraints:
           - node.labels.queue == GPU
     healthcheck:
-      test: ["CMD", "celery", "inspect", "ping", "-A", "rodan", "--workdir", "/code/Rodan", "-d", "celery@GPU"]
+      test: ["CMD", "celery", "inspect", "ping", "-A", "rodan", "--workdir", "/code/Rodan", "-d", "celery@GPU", "-t", "30"]
       interval: "30s"
-      timeout: "10s"
-      retries: 3
+      timeout: "30s"
+      retries: 5
     command: /run/start-celery
     environment:
       TZ: America/Toronto


### PR DESCRIPTION
Resolves #797 on production

1. Loose the healthcheck policy in `rodan-main`, `celery`, and `py3-celery`. Before this pull request (PR) the conditions are quite strict:
```
rodan-main:
      healthcheck:
           interval: "10s"   # Do health check every 10 seconds
           timeout: "5s"     # Need to get the response in 5 seconds. If not, it fails the health check
           retries: 2        # Restart rodan-main when it fails two times in a roll
celery:
       healthcheck:
           test: ["CMD", "celery", "inspect", "ping", "-A", "rodan", "--workdir", "/code/Rodan", "-d", "celery@celery"]
           interval: "30s"
           timeout: "10s"
           start_period: "1m"
           retries: 3
py3-celery:
       healthcheck:
             test: ["CMD", "celery", "inspect", "ping", "-A", "rodan", "--workdir", "/code/Rodan", "-d", "celery@Python3"]
             interval: "30s"
             timeout: "10s"
             retries: 3
gpu-celery:
       healthcheck:
             test: ["CMD", "celery", "inspect", "ping", "-A", "rodan", "--workdir", "/code/Rodan", "-d", "celery@GPU"]
             interval: "30s"
             timeout: "10s"
             retries: 3
```
Containers can easily get restarted because of its strict healthcheck, which results in hanging jobs or missing resources. Change the restart policy, so containers are less unstable.

1. Increase CPUs in `celery` (1→6) and `py3-celery` (1→6), decrease CPUs in `GPU-celery` (6→2): This gives `celery` and `py3-celery` more resources to handle concurrency better. 

2. Reduce the concurrency in `celery`/`py3-celery`: According to several resources and the official celery document, concurrency should be the same as the number of available CPUs, or else celery has to frequently switch between different processes and slow down the machine. Therefore, this PR reduce the concurrency from 10 to 6 since both containers only have access to six CPUs.