### PR TITLE
Fix #804, Convert the input image to RGB mode

### DIFF
--- a/rodan-main/code/rodan/jobs/pil_rodan/red_filtering.py
+++ b/rodan-main/code/rodan/jobs/pil_rodan/red_filtering.py
@@ -29,7 +29,7 @@ class RedFilter(RodanTask):
     }]
 
     def run_my_task(self, inputs, settings, outputs):
-        sal = Image.open(inputs['input'][0]['resource_path'])
+        sal = Image.open(inputs['input'][0]['resource_path']).convert("RGB")
         ImageOps.autocontrast(sal, 0)
          
         red_layer = sal.split()[0]


### PR DESCRIPTION
Resolves #804 
Some images are read as the P mode which raises error in the autocontrast function. Convert the input image to RGB mode to avoid this issue.