### PR TITLE
Update text-alignment reqs to fix tfaip

### DIFF
--- a/rodan-main/code/rodan/jobs/text_alignment/requirements.txt
+++ b/rodan-main/code/rodan/jobs/text_alignment/requirements.txt
@@ -1,6 +1,6 @@
 #numpy==1.17.3; python_version > "3.4"
 git+https://github.com/timothydereuse/calamari@v2.1.4#egg=calamari_ocr; python_version > "3.4"
-git+https://github.com/p42ul/tfaip@3738106#egg=tfaip; python_version > "3.4"
+git+https://github.com/DDMAL/tfaip@f181fe7#egg=tfaip; python_version > "3.4"
 paiargparse==1.1.2; python_version > "3.4"
 scipy; python_version > "3.4"
 Unidecode==1.0.22; python_version > "3.4"


### PR DESCRIPTION
Changes the `tfaip` version to one hosted locally in the DDMAL organization. This fixes #806.
