### PR TITLE
Fix #808, Upgrade from Debian stretch to bullseye in postgres

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,5 +1,5 @@
 # FROM postgres:latest
-FROM postgres:9.6
+FROM postgres:9.6-bullseye
 EXPOSE 5432
 
 RUN apt-get update \


### PR DESCRIPTION
Resolves #808 
Postgres no longer supports debian stretch. Therefore, upgrade it from stretch (postgres:9.6) to bullseye (postgres:9.6-bullseye)