### PR TITLE
Fix #814, Install specific versions of npm and yarn

### DIFF
--- a/python3-celery/Dockerfile
+++ b/python3-celery/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3 AS builder
+FROM alpine:3.16 AS builder
 ARG BRANCH
 ENV BRANCH="${BRANCH:-develop}"
 RUN apk update


### PR DESCRIPTION
Resolves #814 
Use alpine=3.16 to use npm=8.10.0-r0. The latest npm version in alpine=3 is 9.1.2-r0 which causes error when installing pixel-wrapper. Alpine does not support installing a specific version off its packages, so the solution is using alpine3.16 which natively use the npm version we want.

This is the error message when using the incorrect npm version 9.1.2-r0
```
022-11-23T02:58:41Z Step 10/38 : RUN ./node_modules/.bin/gulp develop:rodan
2022-11-23T02:58:41Z ---> Running in af7bdf53cb38
2022-11-23T02:58:44Z [02:58:44] Using gulpfile /pixel_wrapper/gulpfile.js
2022-11-23T02:58:44Z [02:58:44] Starting 'develop:rodan'...
2022-11-23T02:58:44Z [02:58:44] Starting 'develop:lint'...
2022-11-23T02:58:44Z [02:58:44] Starting 'lint-src'...
2022-11-23T02:58:47Z [02:58:47] Finished 'lint-src' after 2.82 s
2022-11-23T02:58:47Z [02:58:47] Starting 'lint-test'...
2022-11-23T02:58:47Z [02:58:47] Finished 'lint-test' after 11 ms
2022-11-23T02:58:47Z [02:58:47] Starting 'lint-gulpfile'...
2022-11-23T02:58:47Z [02:58:47] Finished 'lint-gulpfile' after 34 ms
2022-11-23T02:58:47Z [02:58:47] Finished 'develop:lint' after 2.88 s
2022-11-23T02:58:47Z [02:58:47] Starting 'develop:clean'...
2022-11-23T02:58:47Z [02:58:47] Finished 'develop:clean' after 4.25 ms
2022-11-23T02:58:47Z [02:58:47] Starting 'develop:build-plugins'...
2022-11-23T02:58:49Z �[91m[02:58:49] �[0m�[91m'develop:build-plugins' errored after 1.72 s
2022-11-23T02:58:49Z �[0m�[91m[02:58:49] Error: error:0308010C:digital envelope routines::unsupported
```

The latest npm version when using `apk add npm` in alpine:3 is `9.1.2-r0`, which was built in 2022-11-19. See here: https://pkgs.alpinelinux.org/package/edge/community/x86_64/npm