### PR TITLE
Fix #813, Restart workers to release memory

### DIFF
--- a/python3-celery/Dockerfile
+++ b/python3-celery/Dockerfile
@@ -76,6 +76,6 @@ RUN python3 setup.py install
 RUN pip install opencv-python==4.6.0.66
 
 # Change the concurency for python3 jobs
-RUN sed -i "s/=10/=6/g" /run/start-celery
+RUN sed -i "s/concurrency=10/concurrency=3/g" /run/start-celery
 
 ENTRYPOINT ["/run/start-celery"]

--- a/rodan-main/Dockerfile
+++ b/rodan-main/Dockerfile
@@ -51,4 +51,8 @@ RUN chmod +x /opt/entrypoint \
 # Substitute the build hash for our actual build hash
 RUN sed -i "s/__build_hash__ = \"local\"/__build_hash__ = \"${BUILD_HASH}\"/" /code/Rodan/rodan/__init__.py
 
+# Change the concurrency
+RUN sed -i "s/concurrency=10/concurrency=6/g" /run/start-celery
+RUN sed -i "s/max-tasks-per-child=1/max-tasks-per-child=5/g" /run/start-celery
+
 ENTRYPOINT ["/opt/entrypoint"]

--- a/scripts/start-celery
+++ b/scripts/start-celery
@@ -23,6 +23,6 @@ cd /code/Rodan
 /run/wait-for-app redis:6379
 /run/wait-for-app rodan-main:8000 --timeout=900
 
-runuser -u root -- celery worker -A rodan --workdir /code/Rodan -Q ${CELERY_JOB_QUEUE} --concurrency=10 -n "${CELERY_JOB_QUEUE}" -l INFO --logfile /code/Rodan/rodan-celery-${CELERY_JOB_QUEUE}.log &
+runuser -u root -- celery worker -A rodan --workdir /code/Rodan -Q ${CELERY_JOB_QUEUE} --concurrency=10 --max-tasks-per-child=1 -n "${CELERY_JOB_QUEUE}" -l INFO --logfile /code/Rodan/rodan-celery-${CELERY_JOB_QUEUE}.log &
 child_2=$!
 wait "$child_2"


### PR DESCRIPTION
Resolves #813 
Celery does not release memory after finishing jobs and causes the out-of-memory issue. Jobs will be killed by oom-reaper and hangs forever in Rodan. Restart workers to release memory.

Rules to restart workers in containers:
`py3-celery`: 12G memory on staging and production, 3 workers and restart each worker after doing one job.
`celery`: 12G memory on staging and production, 6 workers and restart each worker after doing 5 jobs.
`gpu-celery`: 8G memory on staging, 45G memory on production, 1 worker and restart each worker after doing one job.