### PR TITLE
Release v2.0.11 to develop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ REPLACE := perl -i -pe
 RODAN_PATH := ./rodan-main/code/rodan
 JOBS_PATH := $(RODAN_PATH)/jobs
 
-PROD_TAG := v2.0.10
+PROD_TAG := v2.0.11
 
 # Individual Commands
 

--- a/production.yml
+++ b/production.yml
@@ -3,7 +3,7 @@ version: "3.4"
 services:
 
   nginx:
-    image: "ddmal/nginx:v2.0.10"
+    image: "ddmal/nginx:v2.0.11"
     deploy:
       replicas: 1
       resources:
@@ -38,7 +38,7 @@ services:
       - "certbot:/etc/letsencrypt"
 
   rodan-main:
-    image: "ddmal/rodan-main:v2.0.10"
+    image: "ddmal/rodan-main:v2.0.11"
     deploy:
       replicas: 1
       resources:
@@ -74,7 +74,7 @@ services:
       - "resources:/rodan/data"
 
   celery:
-    image: "ddmal/rodan-main:v2.0.10"
+    image: "ddmal/rodan-main:v2.0.11"
     deploy:
       replicas: 1
       resources:
@@ -105,7 +105,7 @@ services:
       - "resources:/rodan/data"
 
   py3-celery:
-    image: "ddmal/rodan-python3-celery:v2.0.10"
+    image: "ddmal/rodan-python3-celery:v2.0.11"
     deploy:
       replicas: 1
       resources:
@@ -136,7 +136,7 @@ services:
       - "resources:/rodan/data"
 
   gpu-celery:
-    image: "ddmal/rodan-gpu-celery:v2.0.10"
+    image: "ddmal/rodan-gpu-celery:v2.0.11"
     deploy:
       replicas: 1
       resources:
@@ -192,7 +192,7 @@ services:
       TZ: America/Toronto
 
   postgres:
-    image: "ddmal/postgres-plpython:v2.0.10"
+    image: "ddmal/postgres-plpython:v2.0.11"
     deploy:
       replicas: 1
       endpoint_mode: dnsrr
@@ -246,7 +246,7 @@ services:
       - ./scripts/production.env
 
   hpc-rabbitmq:
-    image: "ddmal/hpc-rabbitmq:v2.0.10"
+    image: "ddmal/hpc-rabbitmq:v2.0.11"
     deploy:
       replicas: 1
       resources:


### PR DESCRIPTION
1. Fix the hanging job problem in staging and production by
-  Loose containers' healthcheck policy
-  Restart workers to release memory
2. Pin npm version to 8.10.0-r0 in python3-celery image
3.  Add CI tests for rodan functionalities and jobs
4. Fix the mode problem in Red filtering
5. Remove invalid input port types in Masking