### PR TITLE
Fix #822, train and save ckpts in the correct order

### DIFF
--- a/scripts/install_gpu_rodan_jobs
+++ b/scripts/install_gpu_rodan_jobs
@@ -41,7 +41,7 @@ which pip3 && $PIP install .
 
 # Install Paco classifier
 cd /
-git clone -b v2.0.1 --depth 1 https://github.com/DDMAL/Paco_classifier.git
+git clone -b v2.0.2 --depth 1 https://github.com/DDMAL/Paco_classifier.git
 mv Paco_classifier .Paco_classifier
 cd .Paco_classifier
 which pip3 && $PIP install .


### PR DESCRIPTION
Resolves: #822 
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

Use v2.0.2 tag in Paco classifier. Sort keys first so data loaders are used in the correct order `(Layer 0, Layer 1, ...)`