### PR TITLE
Release v2.0.12 for staging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ REPLACE := perl -i -pe
 RODAN_PATH := ./rodan-main/code/rodan
 JOBS_PATH := $(RODAN_PATH)/jobs
 
-PROD_TAG := v2.0.11
+PROD_TAG := v2.0.12
 
 # Individual Commands
 

--- a/production.yml
+++ b/production.yml
@@ -3,7 +3,7 @@ version: "3.4"
 services:
 
   nginx:
-    image: "ddmal/nginx:v2.0.11"
+    image: "ddmal/nginx:v2.0.12"
     deploy:
       replicas: 1
       resources:
@@ -38,7 +38,7 @@ services:
       - "certbot:/etc/letsencrypt"
 
   rodan-main:
-    image: "ddmal/rodan-main:v2.0.11"
+    image: "ddmal/rodan-main:v2.0.12"
     deploy:
       replicas: 1
       resources:
@@ -74,7 +74,7 @@ services:
       - "resources:/rodan/data"
 
   celery:
-    image: "ddmal/rodan-main:v2.0.11"
+    image: "ddmal/rodan-main:v2.0.12"
     deploy:
       replicas: 1
       resources:
@@ -105,7 +105,7 @@ services:
       - "resources:/rodan/data"
 
   py3-celery:
-    image: "ddmal/rodan-python3-celery:v2.0.11"
+    image: "ddmal/rodan-python3-celery:v2.0.12"
     deploy:
       replicas: 1
       resources:
@@ -136,7 +136,7 @@ services:
       - "resources:/rodan/data"
 
   gpu-celery:
-    image: "ddmal/rodan-gpu-celery:v2.0.11"
+    image: "ddmal/rodan-gpu-celery:v2.0.12"
     deploy:
       replicas: 1
       resources:
@@ -192,7 +192,7 @@ services:
       TZ: America/Toronto
 
   postgres:
-    image: "ddmal/postgres-plpython:v2.0.11"
+    image: "ddmal/postgres-plpython:v2.0.12"
     deploy:
       replicas: 1
       endpoint_mode: dnsrr
@@ -246,7 +246,7 @@ services:
       - ./scripts/production.env
 
   hpc-rabbitmq:
-    image: "ddmal/hpc-rabbitmq:v2.0.11"
+    image: "ddmal/hpc-rabbitmq:v2.0.12"
     deploy:
       replicas: 1
       resources:

--- a/rodan-main/code/rodan/__init__.py
+++ b/rodan-main/code/rodan/__init__.py
@@ -17,7 +17,7 @@ from .celery import app as celery_app
 # Get version: import rodan; rodan.__version__
 # Version numbers also appear in the API.
 __title__ = "Rodan"
-__version__ = "v2.0.10"
+__version__ = "v2.0.12"
 __copyright__ = "Copyright 2011-2022 Distributed Digital Music Archives & Libraries Lab"
 # If changing this line, also change rodan-main/Dockerfile
 __build_hash__ = "local"


### PR DESCRIPTION
Release v2.0.12 for staging
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.
- Save paco's trained ckpts in the correct order
- Periodically check production and staging websites to know they're still up
- Add testcase for MEI encoding, Heuristic Pitch Finding, and Non-interactive classifier