### PR TITLE
Fix #635, Save button failed after entering workflow canvas

### DIFF
--- a/rodan-client/code/src/js/WorkflowBuilderGUI.js
+++ b/rodan-client/code/src/js/WorkflowBuilderGUI.js
@@ -23,6 +23,7 @@ class WorkflowBuilderGUI
     constructor(options)
     {
         this._oldMouseEvent = window.MouseEvent; // FIX: paper.js stupidly redefines
+        this._event = window.Event; // paper.js stupidly redefines Event and crashes the SAVE button in resources
         this._workflow = null;
         Radio.channel('rodan').on(Rodan.RODAN_EVENTS.EVENT__WORKFLOWBUILDER_SELECTED, (options) => this.initialize(options));
     }
@@ -453,6 +454,7 @@ class WorkflowBuilderGUI
     {
         BaseItem.clearMap();
         window.MouseEvent = this._oldMouseEvent;
+        window.Event = this._event;
     }
 
     /**

--- a/rodan-client/local-dev/arm-compose.yml
+++ b/rodan-client/local-dev/arm-compose.yml
@@ -1,0 +1,127 @@
+version: "3.4"
+services:
+  nginx:
+    image: "nginx-local:latest"
+    command: /run/start
+    depends_on:
+      - rodan-main
+    ports:
+      - "80:80"
+      - "443:443"
+      - "9002:9002"
+    volumes:
+      - "resources:/rodan/data"
+  
+  rodan-main:
+    image: "ddmal/rodan-main:nightly"
+    healthcheck:
+      test: ["CMD-SHELL", "/usr/bin/curl -H 'User-Agent: docker-healthcheck' http://localhost:8000/api/?format=json || exit 1"]
+      interval: "10s"
+      timeout: "5s"
+      retries: 2
+      start_period: "2m"
+    command: bash -c "tail -f /dev/null"
+    environment:
+      CELERY_JOB_QUEUE: None
+    depends_on:
+      - postgres
+      - rabbitmq
+      - redis
+    env_file:
+      - ./scripts/local.env
+    ports:
+      - "8000:8000"
+    volumes:
+      - "resources:/rodan/data"
+      - "./rodan-main/code:/code/Rodan"
+
+
+  iipsrv:
+    image: "ddmal/iipsrv:nightly"
+    volumes:
+      - "resources:/rodan/data"
+
+      
+  celery:
+    image: "ddmal/rodan-main:nightly"
+    command: bash -c "tail -f /dev/null"
+    environment:
+      CELERY_JOB_QUEUE: celery
+    healthcheck:
+      test: ["CMD", "celery", "inspect", "ping", "-A", "rodan", "--workdir", "/code/Rodan", "-d", "celery@celery"]
+      interval: "30s"
+      timeout: "3s"
+      start_period: "1m"
+      retries: 3
+    depends_on:
+      - postgres
+      - rodan-main
+      - rabbitmq
+      - redis
+    env_file:
+      - ./scripts/local.env
+    volumes:
+      - "resources:/rodan/data"
+      - "./rodan-main/code:/code/Rodan"
+
+  py3-celery:
+    image: "ddmal/rodan-python3-celery:nightly"
+    command: bash -c "tail -f /dev/null"
+    environment:
+      CELERY_JOB_QUEUE: Python3
+    depends_on:
+      - postgres
+      - rodan-main
+      - rabbitmq
+      - redis
+      - celery
+    env_file:
+      - ./scripts/local.env
+      - ./hpc-rabbitmq/scripts/local.env
+    volumes:
+      - "resources:/rodan/data"
+      - "./rodan-main/code:/code/Rodan"
+  
+  
+  redis:
+    image: "redis:alpine"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      - postgres
+
+  postgres:
+    image: "ddmal/postgres-plpython:nightly"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready", "-U", "postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    env_file:
+      - ./scripts/local.env
+  
+  rabbitmq:
+    image: "rabbitmq:alpine"
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: "30s"
+      timeout: "3s"
+      retries: 3
+    depends_on:
+      - redis
+    env_file:
+      - ./scripts/local.env
+
+  rodan-client:
+    image: "ddmal/rodan-client:nightly"
+    command: bash -c "tail -f /dev/null"
+    ports:
+      - "8080:9002"
+    volumes:
+      - "./rodan-client/code:/code"
+
+volumes:
+  resources:

--- a/rodan-client/readme.md
+++ b/rodan-client/readme.md
@@ -1,3 +1,18 @@
+## Step-by-step to run Rodan Client on M1
+1. Navigate to rodan. `cp rodan-client/local-dev/arm-compose.yml .`
+2. Navigate to rodan. `make run_arm`
+3. Navigate to rodan. `docker-compose -f arm-compose.yml exec rodan-main /run/start`
+4. Navigate to rodan. `docker-compose -f arm-compose.yml exec celery /run/start-celery`
+5. Navigate to rodan. `docker-compose -f arm-compose.yml exec py3-celery /run/start-celery`
+6. `docker-compose -f arm-compose.yml exec rodan-client bash` to go to rodan-client container
+7. Inside the container: `cd /code; yarn install`
+8. Navigate to rodan-cleint: `cp local-dev/COPYconfiguration code/configuration.json`
+9. Navigate to rodan-client: `cp local-dev/CPCONFIGFILE code/src/js/configuration.js`
+10. Inside the container: `cd /code/node_modules/.bin` 
+11. Inside the container: `yarn global add gulp`
+12. Inside the container: `gulp`
+13. Go to `localhost:8080` on your browser
+
 To Run Rodan Client locally, you must have docker installed and have the docker images pulled from the nightly tag.
 After installing docker, you can continue by replacing the docker-compose file with the one in the local-dev directory under the rodan-client directory. (dont forget to make the nginx container the same way as you do to run Rodan main for M1 systems)
 


### PR DESCRIPTION
Resolves: #635 
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

`Save` button does not work after entering and quitting workflow canvas. This is because the workflow canvas uses `paper.js`, which overrides the default `Event` class, while the `Save` button tries to use the default `Event` class.

Solve this issue by reloading the default Event class back when leaving the workflow canvas