### PR TITLE
Fix #771, disable pagination to show users in one page

### DIFF
--- a/rodan-main/code/rodan/views/user.py
+++ b/rodan-main/code/rodan/views/user.py
@@ -30,6 +30,7 @@ class UserList(generics.ListCreateAPIView):
     permission_classes = (permissions.IsAuthenticated, CustomObjectPermissions)
     _ignore_model_permissions = True
     serializer_class = UserListSerializer
+    pagination_class = None
 
     class filter_class(django_filters.FilterSet):
         # username__in = django_filters.MethodFilter()


### PR DESCRIPTION
Resolves: #771 
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

Some users are on the second page, so they do not appear in the drop-down menu. Disable pagination so users are on one page