### PR TITLE
Rename Old Calvo Jobs

### DIFF
--- a/rodan-main/code/rodan/jobs/Calvo_classifier/README.md
+++ b/rodan-main/code/rodan/jobs/Calvo_classifier/README.md
@@ -4,8 +4,8 @@ Repository of the Rodan wrapper for Calvo classifier
 
 # Rodan Jobs definition
 This repository includes the following Rodan Jobs:
-- `Pixelwise Analysis of Music Document` in **calvo_classifier.py**
-- `Training model for Pixelwise Analysis of Music Document` in **calvo_trainer.py**
+- `Pixelwise Analysis of Music Document [OLD]` in **calvo_classifier.py**
+- `Training model for Pixelwise Analysis of Music Document [OLD]` in **calvo_trainer.py**
 - `Fast Pixelwise Analysis of Music Document` in **fast_calvo_classifier.py**
   - Available in the **python3** Rodan queue.
 - `Training model for Patchwise Analysis of Music Document` in **fast_calvo_trainer.py**

--- a/rodan-main/code/rodan/jobs/Calvo_classifier/calvo_classifier.py
+++ b/rodan-main/code/rodan/jobs/Calvo_classifier/calvo_classifier.py
@@ -13,7 +13,7 @@ from rodan.jobs.base import RodanTask
 """Wrap Calvo classifier in Rodan."""
     
 class CalvoClassifier(RodanTask):
-    name = "Pixelwise Analysis of Music Document"
+    name = "Pixelwise Analysis of Music Document [OLD]"
     author = "Jorge Calvo-Zaragoza, Gabriel Vigliensoni, and Ichiro Fujinaga"
     description = "Given a pre-trained Convolutional neural network, the job performs a pixelwise analysis of music document images." 
     enabled = True

--- a/rodan-main/code/rodan/jobs/Calvo_classifier/calvo_trainer.py
+++ b/rodan-main/code/rodan/jobs/Calvo_classifier/calvo_trainer.py
@@ -13,7 +13,7 @@ from rodan.jobs.base import RodanTask
 
 
 class CalvoTrainer(RodanTask):
-    name = "Training model for Pixelwise Analysis of Music Document"
+    name = "Training model for Pixelwise Analysis of Music Document [OLD]"
     author = "Jorge Calvo-Zaragoza, Gabriel Vigliensoni, and Ichiro Fujinaga"
     description = "The job performs the training of a neural network model for the pixelwise analysis of music document images."
     enabled = True


### PR DESCRIPTION
Rename the calvo jobs that are not fast calvo. Added the tag [OLD] to distinguish from the newer fast calvo jobs

Resolves: (#853)
- [ ] I passed the docker hub test, and images can be built successfully.
- [ ] I passed the GitHub CI test, so rodan functionalities and jobs work.
