### PR TITLE
Remove a reference to fast calvo trainer 

### DIFF
--- a/rodan-main/code/rodan/jobs/Calvo_classifier/__init__.py
+++ b/rodan-main/code/rodan/jobs/Calvo_classifier/__init__.py
@@ -9,4 +9,3 @@ from rodan.jobs import module_loader
 module_loader('rodan.jobs.Calvo_classifier.calvo_classifier')
 module_loader('rodan.jobs.Calvo_classifier.calvo_trainer')
 module_loader('rodan.jobs.Calvo_classifier.fast_calvo_classifier')
-module_loader('rodan.jobs.Calvo_classifier.fast_calvo_trainer')


### PR DESCRIPTION
Upon trying to run the new images locally I found that there was a lingering reference to the fast_calvo_trainer job which caused issues when running. This should fix it!
- [ ] I passed the docker hub test, and images can be built successfully.
- [ ] I passed the GitHub CI test, so rodan functionalities and jobs work.

(Describe the changes you've made and the purpose of this PR)