### PR TITLE
Fix for modal-window opacity

### DIFF
--- a/rodan-client/code/styles/default.scss
+++ b/rodan-client/code/styles/default.scss
@@ -185,7 +185,7 @@ div#main_workflowbuilder
 
 .modal-content
 {
-    opacity: 0.88 !important;
+    opacity: 1 !important;
 }
 
 .modal-backdrop


### PR DESCRIPTION
💄 Changed Rodan modal-window opacity from 0.88 to 1.

Resolves: (#871)
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so Rodan functionalities and jobs work.

All modal windows in Rodan will now have an opacity value of 1. 

The reason this change was requested: It's sometimes hard to see and read things in the modal windows because of the opacity settings. Additionally, there doesn't seem to be any important reason for having slightly transparent modal windows.