### PR TITLE
Fix docker-compose docs inside Rodan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ renew_certbot:
 	@docker exec `docker ps -f name=rodan_nginx -q` nginx -s reload
 
 stop:
-	# This is the same command to stop docker swarm or docker-compose
+	# This is the same command to stop docker swarm or docker compose
 	@echo "[-] Stopping all running docker containers and services..."
 	@docker service rm `docker service ls -q` >>/dev/null 2>&1 || echo "[+] No Services Running"
 	# @docker stop `docker ps -aq` >>/dev/null 2>&1 || echo "[+] No Containers Running"

--- a/readme.md
+++ b/readme.md
@@ -32,11 +32,11 @@ The following commands may seem familiar to you if you have worked with Posix sy
 - To copy files between the container and the host, it is the same way you would use scp between different computers, execute: `docker cp`,
 - Other commands like `docker top` are also available to monitor resources outside of the containers.
 
-A similar concept to using `exec` is using SSH to connect to another computer. We use `exec` to connect to a specific container. It is much simpler to use `docker-compose exec`, instead of the `docker exec`. Docker-compose will search the configuration inside `docker-compose.yml` to know which service is being referenced. The format of the command works this way:
+A similar concept to using `exec` is using SSH to connect to another computer. We use `exec` to connect to a specific container. It is much simpler to use `docker compose exec`, instead of the `docker exec`. Docker compose will search the configuration inside `docker-compose.yml` to know which service is being referenced. The format of the command works this way:
 
-- `docker-compose exec <service_name> <command>`
+- `docker compose exec <service_name> <command>`
 - The command could be anything eg: `/opt/some_directory/my_shell_script.sh`
-- A command you will use frequently is: `docker-compose exec rodan bash` or `docker-compose exec celery bash` for investigating problems. **You should not be using this command to edit files, use `docker volumes` and your IDE outside of the container.**
+- A command you will use frequently is: `docker compose exec rodan bash` or `docker compose exec celery bash` for investigating problems. **You should not be using this command to edit files, use `docker volumes` and your IDE outside of the container.**
 
 Consult the documentation of the [Docker command line](https://docs.docker.com/engine/reference/commandline/cli/) for additional information.
 

--- a/rodan-client/readme.md
+++ b/rodan-client/readme.md
@@ -1,10 +1,10 @@
 ## Step-by-step to run Rodan Client on M1
 1. Navigate to rodan. `cp rodan-client/local-dev/arm-compose.yml .`
 2. Navigate to rodan. `make run_arm`
-3. Navigate to rodan. `docker-compose -f arm-compose.yml exec rodan-main /run/start`
-4. Navigate to rodan. `docker-compose -f arm-compose.yml exec celery /run/start-celery`
-5. Navigate to rodan. `docker-compose -f arm-compose.yml exec py3-celery /run/start-celery`
-6. `docker-compose -f arm-compose.yml exec rodan-client bash` to go to rodan-client container
+3. Navigate to rodan. `docker compose -f arm-compose.yml exec rodan-main /run/start`
+4. Navigate to rodan. `docker compose -f arm-compose.yml exec celery /run/start-celery`
+5. Navigate to rodan. `docker compose -f arm-compose.yml exec py3-celery /run/start-celery`
+6. `docker compose -f arm-compose.yml exec rodan-client bash` to go to rodan-client container
 7. Inside the container: `cd /code; yarn install`
 8. Navigate to rodan-cleint: `cp local-dev/COPYconfiguration code/configuration.json`
 9. Navigate to rodan-client: `cp local-dev/CPCONFIGFILE code/src/js/configuration.js`
@@ -16,9 +16,9 @@
 To Run Rodan Client locally, you must have docker installed and have the docker images pulled from the nightly tag.
 After installing docker, you can continue by replacing the docker-compose file with the one in the local-dev directory under the rodan-client directory. (dont forget to make the nginx container the same way as you do to run Rodan main for M1 systems)
 
-After the installation, you have to `make run` and `docker-compose exec rodan-main /run/start` to have the rodan-main container run.
+After the installation, you have to `make run` and `docker compose exec rodan-main /run/start` to have the rodan-main container run.
 
-Next, you will need to CLI into the rodan client and make some manual changes to the config.json file. do `docker-compose exec rodan-client bash`.
+Next, you will need to CLI into the rodan client and make some manual changes to the config.json file. do `docker compose exec rodan-client bash`.
 
 Now, you are in the rodan-client container. Run `cd /code; yarn install`.
 

--- a/rodan-main/code/rodan/jobs/heuristic_pitch_finding/README.md
+++ b/rodan-main/code/rodan/jobs/heuristic_pitch_finding/README.md
@@ -27,7 +27,7 @@ RODAN_JOB_PACKAGES = (
 
 ## Running Rodan
 - Follow the [rodan-docker guide](https://github.com/DDMAL/rodan-docker/blob/master/README.md) to have docker set up.
-- Once the above installation steps are complete, run ```docker-compose -f docker-compose.yml -f docker-compose.rodan-dev.yml up``` 
+- Once the above installation steps are complete, run ```docker compose -f docker-compose.yml -f docker-compose.rodan-dev.yml up``` 
 
 ## Job Usage
 - To properly setup the pitch finding workflow, connect the *JSOMR* output from a `Miyao Staff Finding` job to the *JSOMR* input of a `Heuristic Pitch Finding` job. 

--- a/starter.sh
+++ b/starter.sh
@@ -2,12 +2,12 @@
 osascript -e 'tell application "iTerm" to activate' -e 'tell application "System Events" to tell process "iTerm" to keystroke "t" using command down' -e 'tell application "System Events" to tell process "iTerm" to keystroke "cd ~/Desktop/Rodan && make run_arm
 "' 
 sleep 30 
-osascript -e 'tell application "iTerm" to activate' -e 'tell application "System Events" to tell process "iTerm" to keystroke "d" using command down' -e 'tell application "System Events" to tell process "iTerm" to keystroke "cd ~/Desktop/Rodan && docker-compose exec rodan-main /run/start
+osascript -e 'tell application "iTerm" to activate' -e 'tell application "System Events" to tell process "iTerm" to keystroke "d" using command down' -e 'tell application "System Events" to tell process "iTerm" to keystroke "cd ~/Desktop/Rodan && docker compose exec rodan-main /run/start
 "' 
 sleep 30 
-osascript -e 'tell application "iTerm" to activate' -e 'tell application "System Events" to tell process "iTerm" to keystroke "d" using command down' -e 'tell application "System Events" to tell process "iTerm" to keystroke "cd ~/Desktop/Rodan && docker-compose exec celery /run/start-celery
+osascript -e 'tell application "iTerm" to activate' -e 'tell application "System Events" to tell process "iTerm" to keystroke "d" using command down' -e 'tell application "System Events" to tell process "iTerm" to keystroke "cd ~/Desktop/Rodan && docker compose exec celery /run/start-celery
 "' 
-osascript -e 'tell application "iTerm" to activate' -e 'tell application "System Events" to tell process "iTerm" to keystroke "d" using command down' -e 'tell application "System Events" to tell process "iTerm" to keystroke "cd ~/Desktop/Rodan && docker-compose exec py3-celery /run/start-celery
+osascript -e 'tell application "iTerm" to activate' -e 'tell application "System Events" to tell process "iTerm" to keystroke "d" using command down' -e 'tell application "System Events" to tell process "iTerm" to keystroke "cd ~/Desktop/Rodan && docker compose exec py3-celery /run/start-celery
 "' 
 echo "######### DEPLOYED #########"
 sleep 20


### PR DESCRIPTION
Resolves: (#870)
- [ ] I passed the docker hub test, and images can be built successfully.
- [ ] I passed the GitHub CI test, so rodan functionalities and jobs work.

Fix the `docker-compose` in the documentations and readmes inside Rodan codebase to `docker compose`