### PR TITLE
[Client] Limit add/delete ports to min/max

### DIFF
--- a/rodan-client/code/src/js/Views/Master/Main/InputPort/ViewInputPortCollectionItem.js
+++ b/rodan-client/code/src/js/Views/Master/Main/InputPort/ViewInputPortCollectionItem.js
@@ -18,9 +18,21 @@ export default class ViewInputPortCollectionItem extends BaseViewCollectionItem
      * @param {object} options Marionette.View options object; 'options.workflow' (Workflow) and 'options.workflowjob' (WorkflowJob) must also be provided
      */
     initialize(options)
-    {
+    {        
         this._workflow = options.workflow;
         this._workflowJob = options.workflowjob;
+        
+        this._minimum = this._getMinimumInputPortCount();
+
+        this._inputPorts = this._workflowJob.get("input_ports");
+        this._inputPorts.on("change add remove reset", () => this._handleInputPortsChange());
+    }
+
+    templateContext()
+    {
+        return {
+            disableDelete: this._getCurrentInputPortCount() <= this._minimum
+        };
     }
 
 ///////////////////////////////////////////////////////////////////////////////////////
@@ -32,6 +44,27 @@ export default class ViewInputPortCollectionItem extends BaseViewCollectionItem
     _handleButtonDelete()
     {
         Radio.channel('rodan').request(RODAN_EVENTS.REQUEST__WORKFLOWBUILDER_REMOVE_INPUTPORT, {inputport: this.model, workflow: this._workflow, workflowjob: this._workflowJob});
+    }
+
+    _handleInputPortsChange()
+    {
+        this.render(); // We need to re-render if the the job's input port changes to disable/enable delete button.
+    }
+
+    _getCurrentInputPortCount()
+    {
+        return this._inputPorts.where({ input_port_type: this.model.get("input_port_type") }).length;
+    }
+
+    _getMinimumInputPortCount()
+    {
+        const jobCollection = Radio.channel('rodan').request(RODAN_EVENTS.REQUEST__GLOBAL_JOB_COLLECTION);
+        const inputPortTypes = jobCollection.get(this._workflowJob.getJobUuid()).get("input_port_types");
+
+        const portTypeUrl = this.model.get("input_port_type");
+        const portType = inputPortTypes.findWhere({url: portTypeUrl});
+
+        return portType.get("minimum");
     }
 }
 ViewInputPortCollectionItem.prototype.ui = {

--- a/rodan-client/code/src/js/Views/Master/Main/InputPortType/ViewInputPortTypeCollectionItem.js
+++ b/rodan-client/code/src/js/Views/Master/Main/InputPortType/ViewInputPortTypeCollectionItem.js
@@ -21,6 +21,15 @@ export default class ViewInputPortTypeCollectionItem extends BaseViewCollectionI
     {
         this._workflowJob = options.workflowjob;
         this._workflow = options.workflow;
+        this._inputPorts = this._workflowJob.get("input_ports");
+        this._inputPorts.on("change add remove reset", () => this._handleInputPortsChange());
+    }
+
+    templateContext() 
+    {
+        return {
+            current: this._getCurrentInputPortCount()
+        };
     }
 
 ///////////////////////////////////////////////////////////////////////////////////////
@@ -32,6 +41,16 @@ export default class ViewInputPortTypeCollectionItem extends BaseViewCollectionI
     _handleButtonNewInputPort()
     {
         Radio.channel('rodan').request(RODAN_EVENTS.REQUEST__WORKFLOWBUILDER_ADD_INPUTPORT, {inputporttype: this.model, workflowjob: this._workflowJob, workflow: this._workflow});
+    }
+
+    _handleInputPortsChange()
+    {
+        this.render(); // We need to re-render if the the job's input port changes to update the current count.
+    }
+
+    _getCurrentInputPortCount()
+    {
+        return this._inputPorts.where({ input_port_type: this.model.get("url") }).length;
     }
 }
 ViewInputPortTypeCollectionItem.prototype.tagName = 'tr';

--- a/rodan-client/code/src/js/Views/Master/Main/OutputPort/ViewOutputPortCollectionItem.js
+++ b/rodan-client/code/src/js/Views/Master/Main/OutputPort/ViewOutputPortCollectionItem.js
@@ -21,6 +21,18 @@ export default class ViewOutputPortCollectionItem extends BaseViewCollectionItem
     {
         this._workflow = options.workflow;
         this._workflowJob = options.workflowjob;
+
+        this._minimum = this._getMinimumOutputPortCount();
+
+        this._outputPorts = this._workflowJob.get("output_ports");
+        this._outputPorts.on("change add remove reset", () => this._handleOutputPortsChange());
+    }
+
+    templateContext()
+    {
+        return {
+            disableDelete: this._getCurrentOutputPortCount() <= this._minimum
+        }
     }
 
 ///////////////////////////////////////////////////////////////////////////////////////
@@ -32,6 +44,27 @@ export default class ViewOutputPortCollectionItem extends BaseViewCollectionItem
     _handleButtonDelete()
     {
         Radio.channel('rodan').request(RODAN_EVENTS.REQUEST__WORKFLOWBUILDER_REMOVE_OUTPUTPORT, {outputport: this.model, workflow: this._workflow, workflowjob: this._workflowJob});
+    }
+
+    _handleOutputPortsChange()
+    {
+        this.render(); // We need to re-render if the the job's output port changes to disable/enable delete button.
+    }
+
+    _getCurrentOutputPortCount()
+    {
+        return this._outputPorts.where({ output_port_type: this.model.get("output_port_type") }).length;
+    }
+
+    _getMinimumOutputPortCount()
+    {
+        const jobCollection = Radio.channel('rodan').request(RODAN_EVENTS.REQUEST__GLOBAL_JOB_COLLECTION);
+        const outputPortTypes = jobCollection.get(this._workflowJob.getJobUuid()).get("output_port_types");
+
+        const portTypeUrl = this.model.get("output_port_type");
+        const portType = outputPortTypes.findWhere({url: portTypeUrl});
+
+        return portType.get("minimum");
     }
 }
 ViewOutputPortCollectionItem.prototype.ui = {

--- a/rodan-client/code/src/js/Views/Master/Main/OutputPortType/ViewOutputPortTypeCollectionItem.js
+++ b/rodan-client/code/src/js/Views/Master/Main/OutputPortType/ViewOutputPortTypeCollectionItem.js
@@ -21,6 +21,15 @@ export default class ViewOutputPortTypeCollectionItem extends BaseViewCollection
     {
         this._workflowJob = options.workflowjob;
         this._workflow = options.workflow;
+        this._outputPorts = this._workflowJob.get("output_ports");
+        this._outputPorts.on("change add remove reset", () => this._handleOutputPortsChange());
+    }
+
+    templateContext()
+    {
+        return {
+            current: this._getCurrentOutputPortCount()
+        }
     }
 
 ///////////////////////////////////////////////////////////////////////////////////////
@@ -32,6 +41,16 @@ export default class ViewOutputPortTypeCollectionItem extends BaseViewCollection
     _handleButtonNewOutputPort()
     {
         Radio.channel('rodan').request(RODAN_EVENTS.REQUEST__WORKFLOWBUILDER_ADD_OUTPUTPORT, {outputporttype: this.model, workflowjob: this._workflowJob, workflow: this._workflow});
+    }
+
+    _handleOutputPortsChange()
+    {
+        this.render(); // We need to re-render if the the job's output port changes to update the current count.
+    }
+
+    _getCurrentOutputPortCount()
+    {
+        return this._outputPorts.where({ output_port_type: this.model.get("url") }).length;
     }
 }
 ViewOutputPortTypeCollectionItem.prototype.tagName = 'tr';

--- a/rodan-client/code/templates/Views/Master/Main/InputPort/Collection/template-main_inputport_collection_item.html
+++ b/rodan-client/code/templates/Views/Master/Main/InputPort/Collection/template-main_inputport_collection_item.html
@@ -1,2 +1,2 @@
 <td><%= label %></td>
-<td><button class="btn btn-xs btn-danger" id="button-delete">Delete</button></td>
+<td><button class="btn btn-xs btn-danger" id="button-delete" <% if (disableDelete) {%> disabled <%} %>>Delete</button></td>

--- a/rodan-client/code/templates/Views/Master/Main/InputPortType/Collection/template-main_inputporttype_collection.html
+++ b/rodan-client/code/templates/Views/Master/Main/InputPortType/Collection/template-main_inputporttype_collection.html
@@ -4,6 +4,7 @@
         <thead>
             <tr>
                 <th>Name</th>
+                <th>Current</th>
                 <th>Min</th>
                 <th>Max</th>
             </tr>

--- a/rodan-client/code/templates/Views/Master/Main/InputPortType/Collection/template-main_inputporttype_collection_item.html
+++ b/rodan-client/code/templates/Views/Master/Main/InputPortType/Collection/template-main_inputporttype_collection_item.html
@@ -1,4 +1,7 @@
 <td><%= name %></td>
+<td><%= current %></td>
 <td><%= minimum %></td>
 <td><%= maximum %></td>
-<td><button class="btn btn-xs btn-warning" id="button-new_inputport">Add</button></td>
+<td>
+    <button class="btn btn-xs btn-warning" id="button-new_inputport" <% if (current >= maximum) {%> disabled <%} %>>Add</button>
+</td>

--- a/rodan-client/code/templates/Views/Master/Main/InputPortType/Collection/template-main_inputporttype_collection_item.html
+++ b/rodan-client/code/templates/Views/Master/Main/InputPortType/Collection/template-main_inputporttype_collection_item.html
@@ -3,5 +3,5 @@
 <td><%= minimum %></td>
 <td><%= maximum %></td>
 <td>
-    <button class="btn btn-xs btn-warning" id="button-new_inputport" <% if (current >= maximum) {%> disabled <%} %>>Add</button>
+    <button class="btn btn-xs btn-warning" id="button-new_inputport" <% if (current >= maximum && maximum !== 0) {%> disabled <%} %>>Add</button>
 </td>

--- a/rodan-client/code/templates/Views/Master/Main/OutputPort/Collection/template-main_outputport_collection_item.html
+++ b/rodan-client/code/templates/Views/Master/Main/OutputPort/Collection/template-main_outputport_collection_item.html
@@ -1,2 +1,2 @@
 <td><%= label %></td>
-<td><button class="btn btn-xs btn-danger" id="button-delete">Delete</button></td>
+<td><button class="btn btn-xs btn-danger" id="button-delete" <% if (disableDelete) {%> disabled <%} %>>Delete</button></td>

--- a/rodan-client/code/templates/Views/Master/Main/OutputPortType/Collection/template-main_outputporttype_collection.html
+++ b/rodan-client/code/templates/Views/Master/Main/OutputPortType/Collection/template-main_outputporttype_collection.html
@@ -4,6 +4,7 @@
         <thead>
             <tr>
                 <th>Name</th>
+                <th>Current</th>
                 <th>Min</th>
                 <th>Max</th>
             </tr>

--- a/rodan-client/code/templates/Views/Master/Main/OutputPortType/Collection/template-main_outputporttype_collection_item.html
+++ b/rodan-client/code/templates/Views/Master/Main/OutputPortType/Collection/template-main_outputporttype_collection_item.html
@@ -1,4 +1,5 @@
 <td><%= name %></td>
+<td><%= current %></td>
 <td><%= minimum %></td>
 <td><%= maximum %></td>
-<td><button class="btn btn-xs btn-warning" id="button-new_outputport">Add</button></td>
+<td><button class="btn btn-xs btn-warning" id="button-new_outputport" <% if (current >= maximum) {%> disabled <%} %>>Add</button></td>

--- a/rodan-client/code/templates/Views/Master/Main/OutputPortType/Collection/template-main_outputporttype_collection_item.html
+++ b/rodan-client/code/templates/Views/Master/Main/OutputPortType/Collection/template-main_outputporttype_collection_item.html
@@ -2,4 +2,6 @@
 <td><%= current %></td>
 <td><%= minimum %></td>
 <td><%= maximum %></td>
-<td><button class="btn btn-xs btn-warning" id="button-new_outputport" <% if (current >= maximum) {%> disabled <%} %>>Add</button></td>
+<td>
+    <button class="btn btn-xs btn-warning" id="button-new_outputport" <% if (current >= maximum && maximum !== 0) {%> disabled <%} %>>Add</button>
+</td>


### PR DESCRIPTION
Resolves #857 
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

(Describe the changes you've made and the purpose of this PR)
- For each port type, display current number of ports and disable add/delete button according to min/max