### PR TITLE
[Client] Fix zoom shortcuts

### DIFF
--- a/rodan-client/code/src/js/WorkflowBuilderGUI.js
+++ b/rodan-client/code/src/js/WorkflowBuilderGUI.js
@@ -137,15 +137,15 @@ class WorkflowBuilderGUI
 
         // 
         window.addEventListener('keydown', (e) => {
-
-            if(e.ctrlKey && e.key === '='){
+            if (e.ctrlKey && e.key === '=') {
+                e.preventDefault();
                 this._handleRequestZoomIn();
-            }
-
-            else if(e.ctrlKey && e.key === '-'){
+                e.preventDefault();
+            } else if (e.ctrlKey && e.key === '-') {
+                e.preventDefault();
                 this._handleRequestZoomOut();
-            }
-            else if (e.ctrlKey && e.key == '0'){
+            } else if (e.ctrlKey && e.key === '0') {
+                e.preventDefault();
                 this._handleRequestZoomReset()
             }
         });


### PR DESCRIPTION
Resolves #727, #856
- [ ] I passed the docker hub test, and images can be built successfully.
- [ ] I passed the GitHub CI test, so rodan functionalities and jobs work.

(Describe the changes you've made and the purpose of this PR)
- Prevent the browser default behaviour of zooming in the page when the zoom shortcuts are pressed on Windows