### PR TITLE
Make new ocr model selectable in rodan client

### DIFF
--- a/rodan-main/code/rodan/jobs/text_alignment/text_alignment.py
+++ b/rodan-main/code/rodan/jobs/text_alignment/text_alignment.py
@@ -30,7 +30,7 @@ class text_alignment(RodanTask):
         'properties': {
             'OCR Model': {
                 'type': 'string',
-                'enum': ['gothic_salzinnes_2021', 'ms73_latinhist_2021'],
+                'enum': ['gothic_salzinnes_2021', 'ms73_latinhist_2021',"gothic_salzinnes_2023"],
                 'default': 'gothic_salzinnes_2021',
                 'description': ('The OCR model used to obtain a \'messy\' transcript, which will '
                                 'then be aligned to the given transcript.')


### PR DESCRIPTION
Resolves: (#ID-of-the-issue)
- [ ] I passed the docker hub test, and images can be built successfully.
- [ ] I passed the GitHub CI test, so rodan functionalities and jobs work.

In my [last pull request](https://github.com/DDMAL/Rodan/pull/906) I made a new ocr model trained on the salzinnes dataset, however I forgot to modify text_alignment.py to make the new model visible to rodan client. This pull request addresses that oversight by modifying text_alignment.py so that the model name is in the ocr models enum.