### PR TITLE
No longer fetch label for each resource seperately

### DIFF
--- a/rodan-client/code/src/js/Behaviors/BehaviorTable.js
+++ b/rodan-client/code/src/js/Behaviors/BehaviorTable.js
@@ -257,7 +257,7 @@ export default class BehaviorTable extends Marionette.Behavior
         var project_resources = Radio.channel('rodan').request(RODAN_EVENTS.REQUEST__RESOURCES_CURRENT, {data: {project: project.id}});
         var labels = new Set();
         project_resources.each(function (resource) {
-            resource.attributes.labels.forEach(function (url) {
+            resource.attributes.labels.forEach(function ({ url }) {
                 labels.add(url);
             });
         });

--- a/rodan-client/code/src/js/Controllers/ControllerResource.js
+++ b/rodan-client/code/src/js/Controllers/ControllerResource.js
@@ -44,7 +44,6 @@ export default class ControllerResource extends BaseController
         Radio.channel('rodan').reply(RODAN_EVENTS.REQUEST__RESOURCE_VIEWER_ACQUIRE, options => this._handleRequestViewer(options));
         Radio.channel('rodan').reply(RODAN_EVENTS.REQUEST__RESOURCES_LOAD, options => this._handleRequestResources(options));
         Radio.channel('rodan').reply(RODAN_EVENTS.REQUEST__RESOURCES_LOAD_NO_PAGE, options => this._handleRequestResourcesNoPagination(options));
-        Radio.channel('rodan').reply(RODAN_EVENTS.REQUEST__RESOURCES_UPDATE_LABELS, () => this._handleRequestUpdateLabels());
         Radio.channel('rodan').reply(RODAN_EVENTS.REQUEST__RESOURCES_CURRENT, options => this._handleCurrentResources(options));
     }
 
@@ -219,14 +218,6 @@ export default class ControllerResource extends BaseController
             success: (response) => this._handleSuccessAcquire(response)
         };
         $.ajax(ajaxOptions);
-    }
-
-    _handleRequestUpdateLabels()
-    {
-        let resources = this._collection;
-        resources.forEach(resource => {
-            resource._updateResourceLabelsFull();
-        });
     }
 
     /**

--- a/rodan-client/code/src/js/Models/Resource.js
+++ b/rodan-client/code/src/js/Models/Resource.js
@@ -20,11 +20,8 @@ export default class Resource extends BaseModel
     {
         this._updateResourceTypeFull();
         this.set('download', this._getDownloadUrl());
-        this.on('change:resource_type', () => { this._updateResourceTypeFull(); this._updateResourceLabelsFull() });
+        this.on('change:resource_type', () => { this._updateResourceTypeFull() });
         this.on('change:resource_file', () => this.set('download', this._getDownloadUrl()));
-
-        this._updateResourceLabelsFull();
-        this.on('change:labels', () => this._updateResourceLabelsFull());
 
         // If the creator is null (i.e. was not uploaded by a person), inject a dummy.
         if (this.get('creator') === null)
@@ -59,8 +56,7 @@ export default class Resource extends BaseModel
             creator: {first_name: null, last_name: null, username: null},
             created: null,
             updated: null,
-            labels: [],
-            resource_label_full: ''
+            labels: []
         };
     }
 
@@ -152,39 +148,6 @@ export default class Resource extends BaseModel
             jsonString = resourceTypeCollection.get(resourceTypeId).toJSON();
         }
         this.set('resource_type_full', jsonString);
-    }
-
-    /**
-     * Updates label names.
-     */
-    _updateResourceLabelsFull()
-    {
-        var resourceLabelCollection = Radio.channel('rodan').request(RODAN_EVENTS.REQUEST__GLOBAL_RESOURCELABEL_COLLECTION);
-        let success = () => {
-            let jsonStrings = [];
-            let resourceLabelIds = this.get('labels').map(url => this.getResourceLabelUuid(url));
-            resourceLabelIds.forEach(id => {
-              let val = resourceLabelCollection.get(id);
-              if (val)
-              {
-                  jsonStrings.push(val.toJSON());
-              }
-              else
-              {
-                  console.warn("skipping label with id " + id);
-              }
-            });
-            this.set('resource_label_full', jsonStrings);
-        };
-        if (this.get('labels').length !== 0)
-        {
-            resourceLabelCollection.fetch({
-                data: {
-                    disable_pagination: true
-                },
-                success: success.bind(this)
-            });
-        }
     }
 
     /**

--- a/rodan-client/code/src/js/Shared/RODAN_EVENTS.js
+++ b/rodan-client/code/src/js/Shared/RODAN_EVENTS.js
@@ -241,8 +241,6 @@ class RODAN_EVENTS
         /** Request a ResourceCollection to be loaded. Takes {data: Object (query parameters)}. Returns ResourceCollection. */
         this.REQUEST__RESOURCES_LOAD = 'REQUEST__RESOURCES_LOAD';
         this.REQUEST__RESOURCES_LOAD_NO_PAGE = 'REQUEST__RESOURCES_LOAD_NO_PAGE';
-        /** Request resource labels to be updated. */
-        this.REQUEST__RESOURCES_UPDATE_LABELS = 'REQUEST__RESOURCES_UPDATE_LABELS';
         /** Request ResourceCollection without reloading if possible. */
         this.REQUEST__RESOURCES_CURRENT = 'REQUEST__RESOURCES_CURRENT';
 

--- a/rodan-client/code/src/js/Views/Master/Main/Resource/Individual/ViewResourceMulti.js
+++ b/rodan-client/code/src/js/Views/Master/Main/Resource/Individual/ViewResourceMulti.js
@@ -26,15 +26,14 @@ export default class ViewResourceMulti extends Marionette.CollectionView
             let modelLabels = model.get('labels');
             if (rtUrl === undefined) {
                 rtUrl = modelResourceTypeURL;
-            }
-            else if (rtUrl !== modelResourceTypeURL) {
+            } else if (rtUrl !== modelResourceTypeURL) {
                 this.isSameType = false;
             }
+            
             if (labels === undefined) {
                 labels = modelLabels;
-                this.labelNames = model.get('resource_label_full');
-            }
-            else if (!_.isEqual(labels, modelLabels)) {
+                this.labelNames = model.get('labels');
+            } else if (!_.isEqual(labels, modelLabels)) {
                 this.isSameLabel = false;
             }
         }

--- a/rodan-client/code/src/js/Views/Master/Main/ResourceLabel/ViewResourceLabel.js
+++ b/rodan-client/code/src/js/Views/Master/Main/ResourceLabel/ViewResourceLabel.js
@@ -28,7 +28,6 @@ export default class ViewResourceLabel extends Marionette.View
         this.model.save({name: newName}, {
             patch: true,
             success: () => {
-                Radio.channel('rodan').request(RODAN_EVENTS.REQUEST__RESOURCES_UPDATE_LABELS);
                 Radio.channel('rodan').request(RODAN_EVENTS.REQUEST__MODAL_HIDE);
             },
             error: () => {

--- a/rodan-client/code/templates/Views/Master/Main/Resource/Collection/template-main_resource_collection_item.html
+++ b/rodan-client/code/templates/Views/Master/Main/Resource/Collection/template-main_resource_collection_item.html
@@ -3,5 +3,5 @@
 <td><%= _.formatFromUTC(created) %></td>
 <td><%= _.formatFromUTC(updated) %></td>
 <td><%= resource_type_full.mimetype %></td>
-<td><%= _.map(resource_label_full, (label) => { return label.name; }) %></td>
+<td><%= _.map(labels, (label) => { return label.name; }) %></td>
 <td><%= !_.isNull(download) %></td>

--- a/rodan-client/code/templates/Views/Master/Main/Resource/Collection/template-modal_resource_collection_item.html
+++ b/rodan-client/code/templates/Views/Master/Main/Resource/Collection/template-modal_resource_collection_item.html
@@ -2,6 +2,6 @@
 <td><%= creator %></td>
 <td><%= _.formatFromUTC(created) %></td>
 <td><%= resource_type_full.mimetype %></td>
-<td><%= _.map(resource_label_full, (label) => { return label.name; }) %></td>
+<td><%= _.map(labels, (label) => { return label.name; }) %></td>
 <td></td>
 <td></td>

--- a/rodan-client/code/templates/Views/Master/Main/Resource/Collection/template-modal_resource_collection_item_assigned.html
+++ b/rodan-client/code/templates/Views/Master/Main/Resource/Collection/template-modal_resource_collection_item_assigned.html
@@ -2,7 +2,7 @@
 <td><%= creator %></td>
 <td><%= _.formatFromUTC(created) %></td>
 <td><%= resource_type_full.mimetype %></td>
-<td><%= _.map(resource_label_full, (label) => { return label.name; }) %></td>
+<td><%= _.map(labels, (label) => { return label.name; }) %></td>
 <td>
   <button type="button" class="move-up btn btn-success btn-xs">&uarr;</button>
 </td>

--- a/rodan-client/code/templates/Views/Master/Main/Resource/Individual/template-main_resource_individual.html
+++ b/rodan-client/code/templates/Views/Master/Main/Resource/Individual/template-main_resource_individual.html
@@ -6,7 +6,7 @@
     <textarea type="text" class="form-control input-sm" id="text-resource_description" name="text-resource_description"><%= _.unescape(description) %></textarea>
     <label for="input-resource_labels">Label(s):</label><br>
     <input type="tags" class="form-control input-sm" id="input-resource_labels"
-        value="<%= _.map(resource_label_full, (label) => { return label.name; }) %>"
+        value="<%= _.map(labels, (label) => { return label.name; }) %>"
         name="input-resource_labels"><br>
     Creator: <%= creator %><br>
     Created: <%= _.formatFromUTC(created) %><br>

--- a/rodan-main/code/rodan/serializers/resource.py
+++ b/rodan-main/code/rodan/serializers/resource.py
@@ -1,10 +1,11 @@
+from rodan.serializers.resourcelabel import ResourceLabelSerializer
 from rodan.models.resource import Resource
 from rest_framework import serializers
 # from rodan.serializers.user import UserListSerializer
 from rodan.serializers import AbsoluteURLField
 
 
-class ResourceSerializer(serializers.HyperlinkedModelSerializer):
+class HyperlinkedResourceSerializer(serializers.HyperlinkedModelSerializer):
     uuid = serializers.CharField(read_only=True)
     creator = serializers.SlugRelatedField(slug_field="username", read_only=True)
     resource_file = AbsoluteURLField(source="resource_url", read_only=True)
@@ -28,3 +29,6 @@ class ResourceSerializer(serializers.HyperlinkedModelSerializer):
             "has_thumb",
         )  # The only updatable fields are: name, resource_type
         fields = "__all__"
+
+class NestedLabelsResourceSerializer(HyperlinkedResourceSerializer):
+    labels = ResourceLabelSerializer(many=True, read_only=True)


### PR DESCRIPTION
Resolves #555 
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

When loading resources, for each resource, we currently fetch a list of all labels. We now include the complete label when serializing resources so there is no longer a need to make a separate request for each resource. As a result, only a single request needs to be made. This improves performance, user experience, and reduces server load.