### PR TITLE
fix IC with another gamera tag

### DIFF
--- a/ci-jobs/Dockerfile
+++ b/ci-jobs/Dockerfile
@@ -29,7 +29,7 @@ RUN yarn install
 RUN yarn build
 
 # Make Gamera files accessible to the main container.
-FROM ddmal/gamera4:v1.0.1 AS gamera
+FROM ddmal/gamera4:fix_IC AS gamera
 
 # This release is based on Debian 11 "Bullseye"
 FROM python:3.7-slim

--- a/python3-celery/Dockerfile
+++ b/python3-celery/Dockerfile
@@ -26,7 +26,7 @@ RUN yarn install
 RUN yarn build
 
 # Make Gamera files accessible to the main container.
-FROM ddmal/gamera4:v1.0.1 AS gamera
+FROM ddmal/gamera4:fix_IC AS gamera
 
 # This release is based on Debian 11 "Bullseye"
 FROM python:3.7-slim

--- a/rodan-main/code/rodan/jobs/interactive_classifier/interactive_classifier.py
+++ b/rodan-main/code/rodan/jobs/interactive_classifier/interactive_classifier.py
@@ -199,8 +199,8 @@ def group_and_correct(glyphs, user_options, training_database, features_file_pat
 
     # Reassigning values after classification
     for i in range(len(gamera_glyphs)):
-        glyphs[i]['class_name'] = gamera_glyphs[i].get_main_id().decode()
-        glyphs[i]['confidence'] = gamera_glyphs[i].get_confidence().decode()
+        glyphs[i]['class_name'] = gamera_glyphs[i].get_main_id() #.decode()
+        glyphs[i]['confidence'] = gamera_glyphs[i].get_confidence() #.decode()
 
     # Adding new glyphs
     for elem in add:
@@ -287,9 +287,14 @@ def serialize_class_names_to_json(settings):
     database = glyphs + training_database
     # Add the glyph short codes
     for image in database:
+        cln=image['class_name']
+        if type(cln)==bytes:
+             cln=cln.decode()
         name_set.add(image['class_name'])
 
     for name in imported_class_names:
+        if type(name)==bytes:
+             name=name.decode()
         name_set.add(name)
 
     settings['class_names'] = list(name_set)


### PR DESCRIPTION
Resolves: (#860)
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

- use a quick-fix version of gamera with docker tag fix_IC
- commented out decode in interactive_classifier.py to work with the new gamera image