### PR TITLE
Only resources which files exist are available as job inputs

### DIFF
--- a/rodan-client/code/src/js/Controllers/ControllerWorkflowBuilder.js
+++ b/rodan-client/code/src/js/Controllers/ControllerWorkflowBuilder.js
@@ -839,7 +839,7 @@ export default class ControllerWorkflowBuilder extends BaseController
         {
             var project = Radio.channel('rodan').request(RODAN_EVENTS.REQUEST__PROJECT_GET_ACTIVE);
             var resourceTypeURLs = this._getCompatibleResourceTypeURLs([inputPort]);
-            var data = {project: project.id, resource_type__in: ''};
+            var data = {project: project.id, resource_type__in: '', file_exists: 'True'};
             var globalResourceTypes = Radio.channel('rodan').request(RODAN_EVENTS.REQUEST__GLOBAL_RESOURCETYPE_COLLECTION);
             var first = true;
             for (var index in resourceTypeURLs)

--- a/rodan-main/code/rodan/views/resource.py
+++ b/rodan-main/code/rodan/views/resource.py
@@ -122,6 +122,12 @@ class ResourceList(generics.ListCreateAPIView):
         elif uploaded == u'False':
             condition &= Q(origin__isnull=False)
 
+        file_exists = self.request.query_params.get('file_exists', None)
+        if file_exists == u'True':
+            condition &= ~Q(resource_file="")
+        elif file_exists == u'False':
+            condition &= Q(resource_file="")
+
         # finding the resourcelist query parameter and adding it to the condition
         resource_list_param = self.request.query_params.get('resource_list', None)
         if resource_list_param is not None:


### PR DESCRIPTION
Resolves: (#625)
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

(Describe the changes you've made and the purpose of this PR)
- In available resources, filter only resources that have a file (i.e. exclude files still being generated)