### PR TITLE
Eliminate redundant requests when loading the workflow builder

### DIFF
--- a/rodan-client/code/src/js/Collections/BaseCollection.js
+++ b/rodan-client/code/src/js/Collections/BaseCollection.js
@@ -96,7 +96,7 @@ export default class BaseCollection extends Backbone.Collection
      * @return {string} string representing UUID of Collection
      * @todo this should be moved to a utility class
      */
-    parseIdFromUrl(url)
+    static parseIdFromUrl(url)
     {
         var lastSlash = url.lastIndexOf('/');
         var subString = url.substring(0, lastSlash);

--- a/rodan-client/code/src/js/Controllers/ControllerWorkflowBuilder.js
+++ b/rodan-client/code/src/js/Controllers/ControllerWorkflowBuilder.js
@@ -25,6 +25,7 @@ import ViewWorkflowCollectionImportItem from 'js/Views/Master/Main/Workflow/Coll
 import WorkflowCollection from 'js/Collections/WorkflowCollection';
 import ViewWorkflowJobGroup from 'js/Views/Master/Main/WorkflowJobGroup/ViewWorkflowJobGroup';
 import ViewSettings from 'js/Views/Master/Main/WorkflowJob/ViewSettings';
+import BaseModel from '../Models/BaseModel';
 
 /**
  * Controller for the WorkflowBuilder.
@@ -655,14 +656,13 @@ export default class ControllerWorkflowBuilder extends BaseController
         for (var connectionUrl in connections)
         {
             var connection = connections[connectionUrl];
-            var connectionModel = new Connection({input_port: connection.inputPort.get('url'),
-                                                  output_port: connection.outputPort.get('url'),
-                                                  url: connectionUrl});
-
-            // TODO - better way to get connections?
-            var connectionId = connectionModel.parseIdFromUrl(connectionUrl);
-            connectionModel.set({uuid: connectionId});
-            connectionModel.fetch();
+            var connectionId = BaseModel.parseIdFromUrl(connectionUrl);
+            var connectionModel = new Connection({
+                input_port: connection.inputPort.get('url'),
+                output_port: connection.outputPort.get('url'),
+                url: connectionUrl,
+                uuid: connectionId
+            });
             workflow.get('connections').add(connectionModel);
         }
 

--- a/rodan-client/code/src/js/Controllers/ItemController.js
+++ b/rodan-client/code/src/js/Controllers/ItemController.js
@@ -330,8 +330,6 @@ class ItemController
                     case 'WorkflowJob':
                     {
                         var item = new WorkflowJobItem({segments: this._segments.workflowJobItem, model: options.model, text: true});
-                        var position = new paper.Point(paper.view.size.width * paper.view.zoom / 2, paper.view.size.height * paper.view.zoom / 2);
-                        item.setPosition(position);
                         break;
                     }
 

--- a/rodan-client/code/src/js/Items/BaseItem.js
+++ b/rodan-client/code/src/js/Items/BaseItem.js
@@ -204,13 +204,8 @@ class BaseItem extends paper.Path
      */
     loadCoordinates()
     {
-        // Create callback.
-        var callback = (coordinates) => this._handleCoordinateLoadSuccess(coordinates);
 
-        // Fetch.
-        var query = {};
-        query[this.coordinateSetInfo['url']] = this._modelId;
-        this._model.fetch({data: query, success: callback, error: callback});
+        this._handleCoordinateLoadSuccess(this._model);
     }
 
     /**

--- a/rodan-client/code/src/js/Models/BaseModel.js
+++ b/rodan-client/code/src/js/Models/BaseModel.js
@@ -94,7 +94,7 @@ export default class BaseModel extends Backbone.Model
      * @return {string} UUID
      * @todo this should be in a utility file
      */
-    parseIdFromUrl(url)
+    static parseIdFromUrl(url)
     {
         var lastSlash = url.lastIndexOf('/');
         var subString = url.substring(0, lastSlash);


### PR DESCRIPTION
Resolves: (#924)
- [ ] I passed the docker hub test, and images can be built successfully.
- [ ] I passed the GitHub CI test, so rodan functionalities and jobs work.

(Describe the changes you've made and the purpose of this PR)
- Originally, we fetch each workflow jobs to get their coordinates when placing them on the screen. 
- We already have the coordinates, so this is redundant. Likewise, we individually fetch each connection when we already have all the information.
- Jobs used to be created in the center of the screen, then slowly snap to their correct positions as their coordinates load, which is no longer the case. 