### PR TITLE
Wait for the user to stop typing before making a search request

### DIFF
--- a/rodan-client/code/src/js/Behaviors/BehaviorTable.js
+++ b/rodan-client/code/src/js/Behaviors/BehaviorTable.js
@@ -27,6 +27,7 @@ export default class BehaviorTable extends Marionette.Behavior
         this._lastTarget = null;
         this._multipleSelectionKey = Environment.getMultipleSelectionKey();
         this._rangeSelectionKey = Environment.getRangeSelectionKey();
+        this._submitSearch = _.debounce((filters) => this.view.collection.fetchFilter(filters), Configuration.SEARCH_DEBOUNCE_DELAY);
     }
 
     /**
@@ -314,7 +315,7 @@ export default class BehaviorTable extends Marionette.Behavior
                 filters[name].push(value);
             }
         }
-        this.view.collection.fetchFilter(filters);
+        this._submitSearch(filters);
     }
 
     /**

--- a/rodan-client/code/src/js/Configuration.js
+++ b/rodan-client/code/src/js/Configuration.js
@@ -73,6 +73,9 @@ var Configuration = {
     // Interval (in milliseconds) that the RunJob controller will use to reacquire interactive locks.
     RUNJOB_ACQUIRE_INTERVAL: 5000,
 
+    // Time (in miliseconds) that the client will wait before submitting a search.
+    SEARCH_DEBOUNCE_DELAY: 400,
+
 ///////////////////////////////////////////////////////////////////////////////////////
 // DON'T EDIT BELOW THIS LINE (unless you know what you're doing)
 ///////////////////////////////////////////////////////////////////////////////////////

--- a/rodan-client/local-dev/CPCONFIGFILE
+++ b/rodan-client/local-dev/CPCONFIGFILE
@@ -73,6 +73,9 @@ var Configuration = {
     // Interval (in milliseconds) that the RunJob controller will use to reacquire interactive locks.
     RUNJOB_ACQUIRE_INTERVAL: 5000,
 
+    // Time (in miliseconds) that the client will wait before submitting a search.
+    SEARCH_DEBOUNCE_DELAY: 400,
+
 ///////////////////////////////////////////////////////////////////////////////////////
 // DON'T EDIT BELOW THIS LINE (unless you know what you're doing)
 ///////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Resolves: (#925)
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

(Describe the changes you've made and the purpose of this PR)
- Set a short timer before making a request and reset the timer each time a keystroke is made so that a request is made only when the user is finished typing