### PR TITLE
Automate docker tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ JOBS_PATH := $(RODAN_PATH)/jobs
 
 PROD_TAG := v2.0.14
 
+DOCKER_TAG := nightly
+
 # Individual Commands
 
 build:
@@ -43,7 +45,7 @@ restore_db:
 run: remote_jobs
 	# Run local version for dev
 	# Hello, 2022 hires!
-	@docker compose up
+	@DOCKER_TAG=$(DOCKER_TAG) docker compose up
 
 test_prod: pull_prod 
 	# Test production Rodan images with specified tag
@@ -52,12 +54,12 @@ test_prod: pull_prod
 	docker compose -f test-prod-compose.yml up
 
 build_arm:
-	@docker build -f ./nginx/Dockerfile.arm --no-cache --tag nginx-local nginx
+	@docker build -f ./nginx/Dockerfile.arm --no-cache --tag nginx-local --build-arg VERSION=${DOCKER_TAG} nginx
 
 run_arm:
 	# Run build_arm first if you don't have the NGINX container.
 	# Launch ARM instance 
-	@docker compose -f arm-compose.yml up
+	@DOCKER_TAG=$(DOCKER_TAG) docker compose up -f arm-compose.yml up
 
 run_client:
 	# Run Rodan-Client for dev (needs local dev up and running)

--- a/arm-compose.yml
+++ b/arm-compose.yml
@@ -13,7 +13,7 @@ services:
       - "resources:/rodan/data"
   
   rodan-main:
-    image: "ddmal/rodan-main:nightly"
+    image: "ddmal/rodan-main:${DOCKER_TAG}"
     healthcheck:
       test: ["CMD-SHELL", "/usr/bin/curl -H 'User-Agent: docker-healthcheck' http://localhost:8000/api/?format=json || exit 1"]
       interval: "10s"
@@ -41,7 +41,7 @@ services:
 
       
   celery:
-    image: "ddmal/rodan-main:nightly"
+    image: "ddmal/rodan-main:${DOCKER_TAG}"
     command: bash -c "tail -f /dev/null"
     environment:
       CELERY_JOB_QUEUE: celery
@@ -63,7 +63,7 @@ services:
       - "./rodan-main/code:/code/Rodan"
 
   py3-celery:
-    image: "ddmal/rodan-python3-celery:nightly"
+    image: "ddmal/rodan-python3-celery:${DOCKER_TAG}"
     command: bash -c "tail -f /dev/null"
     environment:
       CELERY_JOB_QUEUE: Python3
@@ -92,7 +92,7 @@ services:
       - postgres
 
   postgres:
-    image: "ddmal/postgres-plpython:nightly"
+    image: "ddmal/postgres-plpython:${DOCKER_TAG}"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready", "-U", "postgres"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.4"
 services:
   nginx:
-    image: "ddmal/nginx:nightly"
+    image: "ddmal/nginx:${DOCKER_TAG}"
     command: /run/start
     depends_on:
       - celery
@@ -17,7 +17,7 @@ services:
       - "resources:/rodan/data"
 
   rodan-main:
-    image: "ddmal/rodan-main:nightly"
+    image: "ddmal/rodan-main:${DOCKER_TAG}"
     healthcheck:
       test: ["CMD-SHELL", "/usr/bin/curl -H 'User-Agent: docker-healthcheck' http://localhost:8000/api/?format=json || exit 1"]
       interval: "10s"
@@ -44,7 +44,7 @@ services:
       - "resources:/rodan/data"
 
   celery:
-    image: "ddmal/rodan-main:nightly"
+    image: "ddmal/rodan-main:${DOCKER_TAG}"
     command: bash -c "tail -f /dev/null"
     environment:
       CELERY_JOB_QUEUE: celery
@@ -66,7 +66,7 @@ services:
       - "./rodan-main/code:/code/Rodan"
 
   py3-celery:
-    image: "ddmal/rodan-python3-celery:nightly"
+    image: "ddmal/rodan-python3-celery:${DOCKER_TAG}"
     command: bash -c "tail -f /dev/null"
     environment:
       CELERY_JOB_QUEUE: Python3
@@ -84,7 +84,7 @@ services:
       - "./rodan-main/code:/code/Rodan"
 
   gpu-celery:
-    image: "ddmal/rodan-gpu-celery:nightly"
+    image: "ddmal/rodan-gpu-celery:${DOCKER_TAG}"
     command: bash -c "tail -f /dev/null"
     environment:
       CELERY_JOB_QUEUE: GPU
@@ -111,7 +111,7 @@ services:
       - postgres
 
   postgres:
-    image: "ddmal/postgres-plpython:nightly"
+    image: "ddmal/postgres-plpython:${DOCKER_TAG}"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready", "-U", "postgres"]
       interval: 10s
@@ -133,7 +133,7 @@ services:
       - ./scripts/local.env
 
   hpc-rabbitmq:
-    image: "ddmal/hpc-rabbitmq:nightly"
+    image: "ddmal/hpc-rabbitmq:${DOCKER_TAG}"
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
       interval: "30s"

--- a/hooks/build
+++ b/hooks/build
@@ -1,7 +1,6 @@
 #!/bin/bash
 # hooks/build
 # https://docs.docker.com/docker-cloud/builds/advanced/
-set -o errexit
 
 # This "useless" image is build to prevent dockerhub from overwriting
 # the nightly image with it's obligatory minimum of a build rule. If we want a build
@@ -10,10 +9,25 @@ docker build \
   --tag ddmal/rodan:placeholder \
   .
 
-RODAN_TAG=`cd rodan-main/code && git describe --tags --always`
-RODAN_CLIENT_TAG=`cd rodan-client/code && git describe --tags --always`
-RODAN_DOCKER_TAG=`git describe --tags --always`
-BUILD_HASH=`git rev-parse --verify HEAD`
+# RODAN_TAG=`cd rodan-main/code && git describe --tags --always`
+# RODAN_CLIENT_TAG=`cd rodan-client/code && git describe --tags --always`
+# RODAN_DOCKER_TAG=`git describe --tags --always`
+
+source ./hooks/helper.sh
+DOCKER_TAG=$(GetDockerTag $DOCKER_TAG) || ret_code=$?
+if [[ ret_code -eq 1 ]]; then
+  echo "[-] no branch detected, fallback to use docker tag=$DOCKER_TAG"
+  echo "[-] Stop building due to wrong tag: $DOCKER_TAG"
+  exit 1
+elif [[ ret_code -eq 2 ]]; then
+  echo "[-] no tag on release branch, fallback to use docker tag=$DOCKER_TAG"
+  echo "[-] Stop building due to wrong tag: $DOCKER_TAG"
+  exit 1
+fi
+
+echo "[+] Building images with tag: $DOCKER_TAG"
+
+set -o errexit
 
 ###############################################################################
 # Stage 1
@@ -25,22 +39,13 @@ echo "[+] Building Python3-Celery"
 docker build \
   --no-cache \
   --build-arg BRANCHES="develop" \
-  --build-arg VERSION=${RODAN_TAG} \
-  --tag ddmal/rodan-python3-celery:nightly \
-  --tag ddmal/rodan-python3-celery:${RODAN_TAG} \
+  --build-arg VERSION=${DOCKER_TAG} \
+  --tag ddmal/rodan-python3-celery:${DOCKER_TAG} \
   --file ./python3-celery/Dockerfile \
   .
 
-echo "[+] Pushing Python3-Celery"
-docker push ddmal/rodan-python3-celery:nightly
-
-echo "[+] Python3-Celery needs to be made and pushed before Rodan/Celery because the Rodan image uses the Python3 image as its base."
-
-if [ -z `echo ${RODAN_TAG} | awk -F'-' '{print $3}'` ]; then
-  echo "[+] New tagged image for Python3-Celery: ${RODAN_TAG}"
-  docker push ddmal/rodan-python3-celery:${RODAN_TAG}
-fi
-
+echo "[+] Pushing ddmal/rodan-python3-celery:${DOCKER_TAG}"
+docker push ddmal/rodan-python3-celery:${DOCKER_TAG}
 
 ###############################################################################
 # Stage 2
@@ -48,14 +53,14 @@ fi
 
 echo "[+] Building Rodan & Celery Core"
 
+BUILD_HASH=`git rev-parse --verify HEAD`
 # Don't remove --no-cache
 docker build \
   --no-cache \
   --build-arg BRANCHES="develop" \
-  --build-arg VERSION=${RODAN_TAG} \
+  --build-arg VERSION=${DOCKER_TAG} \
   --build-arg build_hash=${BUILD_HASH} \
-  --tag ddmal/rodan-main:nightly \
-  --tag ddmal/rodan-main:${RODAN_TAG} \
+  --tag ddmal/rodan-main:${DOCKER_TAG} \
   --file ./rodan-main/Dockerfile \
   .
 
@@ -71,28 +76,15 @@ echo "[+] Building Rodan-Client"
 docker build \
   --no-cache \
   --build-arg BRANCHES="develop" \
-  --build-arg VERSION=${RODAN_CLIENT_TAG} \
-  --tag ddmal/rodan-client:nightly \
-  --tag ddmal/rodan-client:${RODAN_CLIENT_TAG} \
+  --build-arg VERSION=${DOCKER_TAG} \
+  --tag ddmal/rodan-client:${DOCKER_TAG} \
   ./rodan-client
 
-echo "[+] Pushing Rodan & Celery Core"
+echo "[+] Pushing ddmal/rodan-main:${DOCKER_TAG}"
+docker push ddmal/rodan-main:${DOCKER_TAG}
 
-if [ -z `echo ${RODAN_TAG} | awk -F'-' '{print $3}'` ]; then
-  echo "[+] New tagged image for Rodan/Celery: ${RODAN_TAG}"
-  docker push ddmal/rodan-main:${RODAN_TAG}
-fi
-
-docker push ddmal/rodan-main:nightly
-
-echo "[+] Pushing Rodan-Client"
-
-if [ -z `echo ${RODAN_CLIENT_TAG} | awk -F'-' '{print $3}'` ]; then
-  echo "[+] New tagged image for rodan-client: ${RODAN_CLIENT_TAG}"
-  docker push ddmal/rodan-client:${RODAN_CLIENT_TAG}
-fi
-
-docker push ddmal/rodan-client:nightly
+echo "[+] Pushing ddmal/rodan-client:${DOCKER_TAG}"
+docker push ddmal/rodan-client:${DOCKER_TAG}
 
 ##############################################################################
 # Stage 3
@@ -103,9 +95,8 @@ echo "[+] Building GPU-Celery"
 docker build \
   --no-cache \
   --build-arg BRANCHES="develop" \
-  --build-arg VERSION=${RODAN_TAG} \
-  --tag ddmal/rodan-gpu-celery:nightly \
-  --tag ddmal/rodan-gpu-celery:${RODAN_TAG} \
+  --build-arg VERSION=${DOCKER_TAG} \
+  --tag ddmal/rodan-gpu-celery:${DOCKER_TAG} \
   --file ./gpu-celery/Dockerfile \
   .
 
@@ -113,9 +104,8 @@ echo "[+] Building Postgres"
 
 docker build \
   --no-cache \
-  --build-arg VERSION=${RODAN_DOCKER_TAG} \
-  --tag ddmal/postgres-plpython:nightly \
-  --tag ddmal/postgres-plpython:${RODAN_DOCKER_TAG} \
+  --build-arg VERSION=${DOCKER_TAG} \
+  --tag ddmal/postgres-plpython:${DOCKER_TAG} \
   --file ./postgres/Dockerfile \
   .
 
@@ -123,18 +113,16 @@ echo "[+] Building Nginx"
 
 docker build \
   --no-cache \
-  --build-arg VERSION=${RODAN_DOCKER_TAG} \
-  --tag ddmal/nginx:nightly \
-  --tag ddmal/nginx:${RODAN_DOCKER_TAG} \
+  --build-arg VERSION=${DOCKER_TAG} \
+  --tag ddmal/nginx:${DOCKER_TAG} \
   ./nginx
 
 echo "[+] Building HPC-RabbitMQ"
 
 docker build \
   --no-cache \
-  --build-arg VERSION=${RODAN_DOCKER_TAG} \
-  --tag ddmal/hpc-rabbitmq:nightly \
-  --tag ddmal/hpc-rabbitmq:${RODAN_DOCKER_TAG} \
+  --build-arg VERSION=${DOCKER_TAG} \
+  --tag ddmal/hpc-rabbitmq:${DOCKER_TAG} \
   ./hpc-rabbitmq
 
 echo "[+] Finished"

--- a/hooks/build
+++ b/hooks/build
@@ -64,13 +64,6 @@ docker build \
   --file ./rodan-main/Dockerfile \
   .
 
-echo "[+] Building iipsrv"
-
-docker build \
-  --no-cache \
-  --tag ddmal/iipsrv:nightly \
-  ./iipsrv
-
 echo "[+] Building Rodan-Client"
 
 docker build \

--- a/hooks/helper.sh
+++ b/hooks/helper.sh
@@ -1,0 +1,27 @@
+GetDockerTag() {
+    current_branch_full=$(git symbolic-ref HEAD) # ref/heads/<branch name> or pull/#PR-id/head
+    current_branch_short=$(git symbolic-ref --short HEAD) # <branch name> or ?
+    _DOCKER_TAG=$1
+
+    # Release branch will always use git tag
+    if [[ $current_branch_short =~ ^release ]]; then
+        # Search for tag in release branch
+        tags=$(git tag --points-at HEAD) # git tags attached to theh HEAD
+        _DOCKER_TAG=$(echo $tags | sed -n '1p')
+        if [[ -z $_DOCKER_TAG ]]; then
+            # echo "no tag on release branch, fallback to use docker tag=release"
+            _DOCKER_TAG="release"
+            echo $_DOCKER_TAG
+            return 2
+        fi
+    elif [[ $_DOCKER_TAG =~ ^placeholder$ ]]; then
+        # develop branch has a weird funny tag called placeholder, change it to nightly so commits and PRs will use the nightly tag
+        _DOCKER_TAG="nightly"
+    fi
+    # Finally, use custom tags send by docker hub. e.g.: a feature branch that has its build rule on docker hub
+
+    # Replace invalid char / in docker tag with - 
+    _DOCKER_TAG=$(echo $_DOCKER_TAG | sed 's/\//-/g')
+    echo $_DOCKER_TAG
+    return 0
+}

--- a/hooks/push
+++ b/hooks/push
@@ -2,46 +2,36 @@
 # hooks/post_push
 # https://docs.docker.com/docker-cloud/builds/advanced/
 
-RODAN_TAG=`cd rodan-main/code && git describe --tags --always`
-RODAN_CLIENT_TAG=`cd rodan-client/code && git describe --tags --always`
-RODAN_DOCKER_TAG=`git describe --tags --always`
-
-echo "[+] Pushing Python3-Celery"
-
-if [ -z `echo ${RODAN_TAG} | awk -F'-' '{print $3}'` ]; then
-  docker push ddmal/rodan-python3-celery:${RODAN_TAG}
+source ./hooks/helper.sh
+DOCKER_TAG=$(GetDockerTag $DOCKER_TAG) || ret_code=$?
+if [[ ret_code -eq 1 ]]; then
+  echo "[-] no branch detected, fallback to use docker tag=$DOCKER_TAG"
+  echo "[-] Stop building due to wrong tag: $DOCKER_TAG"
+  exit 1
+elif [[ ret_code -eq 2 ]]; then
+  echo "[-] no tag on release branch, fallback to use docker tag=$DOCKER_TAG"
+  echo "[-] Stop building due to wrong tag: $DOCKER_TAG"
+  exit 1
 fi
 
-docker push ddmal/rodan-python3-celery:nightly
+echo "[+] Building images with tag: $DOCKER_TAG"
+echo "Docker tag: $DOCKER_TAG"
 
-echo "[+] Pushing GPU-Celery"
+# RODAN_TAG=`cd rodan-main/code && git describe --tags --always`
+# RODAN_CLIENT_TAG=`cd rodan-client/code && git describe --tags --always`
+# RODAN_DOCKER_TAG=`git describe --tags --always`
 
-if [ -z `echo ${RODAN_TAG} | awk -F'-' '{print $3}'` ]; then
-  docker push ddmal/rodan-gpu-celery:${RODAN_TAG}
-fi
+echo "[+] Pushing ddmal/rodan-python3-celery:${DOCKER_TAG}"
+docker push ddmal/rodan-python3-celery:${DOCKER_TAG}
 
-docker push ddmal/rodan-gpu-celery:nightly
+echo "[+] Pushing ddmal/rodan-gpu-celery:${DOCKER_TAG}"
+docker push ddmal/rodan-gpu-celery:${DOCKER_TAG}
 
-echo "[+] Pushing Postgres"
+echo "[+] Pushing ddmal/postgres-plpython:${DOCKER_TAG}"
+docker push ddmal/postgres-plpython:${DOCKER_TAG}
 
-if [ -z `echo ${RODAN_DOCKER_TAG} | awk -F'-' '{print $3}'` ]; then
-  docker push ddmal/postgres-plpython:${RODAN_DOCKER_TAG}
-fi
+echo "[+] Pushing ddmal/nginx:${DOCKER_TAG}"
+docker push ddmal/nginx:${DOCKER_TAG}
 
-docker push ddmal/postgres-plpython:nightly
-
-echo "[+] Pushing Nginx"
-
-if [ -z `echo ${RODAN_DOCKER_TAG} | awk -F'-' '{print $3}'` ]; then
-  docker push ddmal/nginx:${RODAN_DOCKER_TAG}
-fi
-
-docker push ddmal/nginx:nightly
-
-echo "[+] Pushing HPC-RabbitMQ"
-
-if [ -z `echo ${RODAN_DOCKER_TAG} | awk -F'-' '{print $3}'` ]; then
-  docker push ddmal/hpc-rabbitmq:${RODAN_DOCKER_TAG}
-fi
-
-docker push ddmal/hpc-rabbitmq:nightly
+echo "[+] Pushing ddmal/hpc-rabbitmq:${DOCKER_TAG}"
+docker push ddmal/hpc-rabbitmq:${DOCKER_TAG}

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,5 @@
-FROM ddmal/rodan-client:nightly as webapp
+ARG VERSION
+FROM ddmal/rodan-client:${VERSION} as webapp
 
 # Add local configuration and build.
 RUN rm -rf /code/configuration.json
@@ -7,7 +8,7 @@ RUN /code/node_modules/.bin/gulp dist
 
 
 ###########################################################
-FROM ddmal/rodan-main:nightly as rodan-static
+FROM ddmal/rodan-main:${VERSION} as rodan-static
 
 RUN touch /code/Rodan/database.log /code/Rodan/rodan.log
 

--- a/nginx/Dockerfile.arm
+++ b/nginx/Dockerfile.arm
@@ -1,4 +1,5 @@
-FROM ddmal/rodan-client:nightly as webapp
+ARG VERSION
+FROM ddmal/rodan-client:${VERSION} as webapp
 
 # Add local configuration and build.
 RUN rm -rf /code/configuration.json
@@ -7,7 +8,7 @@ RUN /code/node_modules/.bin/gulp dist
 
 
 ###########################################################
-FROM ddmal/rodan-main:nightly as rodan-static
+FROM ddmal/rodan-main:${VERSION} as rodan-static
 
 RUN touch /code/Rodan/database.log /code/Rodan/rodan.log
 

--- a/rodan-main/Dockerfile
+++ b/rodan-main/Dockerfile
@@ -1,7 +1,8 @@
-FROM ddmal/rodan-python3-celery:nightly
 ARG BRANCHES
 ARG VERSION
 ARG BUILD_HASH
+
+FROM ddmal/rodan-python3-celery:${VERSION}
 
 # Install OpenJPEG dependencies.
 RUN \


### PR DESCRIPTION
Resolves: (#931)
- [ ] I passed the docker hub test, and images can be built successfully.
- [ ] I passed the GitHub CI test, so rodan functionalities and jobs work.

Three rules to generate docker tags: `nightly`/`<custom docker tag>`/`<git tag>`
    - `nightly`: Used when building images on develop branch or testing pull requests to develop branch
    - `<custom docker tag>:` When someone sets a build rule on Docker Hub. links to a branch, and sets a custom docker tag,
      the docker tag is automatically used as the tag. Use `docker pull ddmal/<image bane>:<gut branch name>` to pull images
      based on the codebase in that branch.
    - `<git tag>`: When a build rule is based on a release branch named `release*`, use the first git tag on `HEAD`
      as the docker tag. Only support single tag and terminate the automatic build/push when there's no tag.

    Terminate automatic build/push when:
    - there's no tag on release branch
    - there's no branch so the docker tag is empty

    Usage:
    - make run: pull and use the nightly tag
    - make run DOCKER_RAG=<docker tag>: pull and images using the <docker tag> tag
    - make run_arm: for M1/M2
    - make run_arm DOCKER_RAG=<docker tag>: for M1/M2