### PR TITLE
Django 2.0.13 Migration Fixes

### DIFF
--- a/rodan-main/code/rodan/admin/helpers.py
+++ b/rodan-main/code/rodan/admin/helpers.py
@@ -96,6 +96,8 @@ def view_or_basicauth(view, request, test_func, realm="", *args, **kwargs):
             # NOTE: We are only supporting basic authentication for now.
             if auth[0].lower() == "basic":
                 uname, passwd = base64.b64decode(auth[1]).split(b':')
+                uname = uname.decode(encoding='UTF-8')
+                passwd = passwd.decode(encoding='UTF-8')
                 user = authenticate(username=uname, password=passwd)
                 if user is not None:
                     if user.is_active:

--- a/rodan-main/code/rodan/settings.py
+++ b/rodan-main/code/rodan/settings.py
@@ -323,7 +323,7 @@ TEMPLATES = [
 ]
 
 # Middleware classes
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.gzip.GZipMiddleware",
@@ -339,7 +339,7 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
-    "django.contrib.auth.middleware.SessionAuthenticationMiddleware",
+    # "django.contrib.auth.middleware.SessionAuthenticationMiddleware",
 ]
 FILE_UPLOAD_HANDLERS = ["django.core.files.uploadhandler.TemporaryFileUploadHandler"]
 FILE_UPLOAD_PERMISSIONS =  0o644

--- a/rodan-main/code/rodan/views/project.py
+++ b/rodan-main/code/rodan/views/project.py
@@ -15,7 +15,7 @@ class ProjectList(generics.ListCreateAPIView):
     """
 
     permission_classes = (permissions.IsAuthenticated,)
-    queryset = Project.objects.all()
+    #queryset = Project.objects.all()
     serializer_class = ProjectListSerializer
     filter_fields = {
         "updated": ["lt", "gt"],
@@ -25,6 +25,20 @@ class ProjectList(generics.ListCreateAPIView):
         "name": ["exact", "icontains"],
         "description": ["exact", "icontains"],
     }
+
+    def get_queryset(self):
+        # Retrieve the base queryset
+        queryset = Project.objects.all()
+
+        # Apply additional filtering based on user permissions
+        user = self.request.user
+        if not user.is_superuser:
+            # Filter projects based on the creator or user's permissions logic
+            queryset = queryset.filter(
+                creator=self.request.user #| Q(<your_permissions_logic_here>)
+            )
+
+        return queryset
 
     def perform_create(self, serializer):
         serializer.save(creator=self.request.user)

--- a/rodan-main/code/rodan/views/project.py
+++ b/rodan-main/code/rodan/views/project.py
@@ -5,6 +5,8 @@ from django.contrib.auth.models import User
 from rodan.models.project import Project
 from rodan.serializers.project import ProjectListSerializer, ProjectDetailSerializer
 from rodan.permissions import CustomObjectPermissions
+from django.db.models import Q
+
 
 
 class ProjectList(generics.ListCreateAPIView):
@@ -35,7 +37,7 @@ class ProjectList(generics.ListCreateAPIView):
         if not user.is_superuser:
             # Filter projects based on the creator or user's permissions logic
             queryset = queryset.filter(
-                creator=self.request.user #| Q(<your_permissions_logic_here>)
+                Q(creator=user) | Q(admin_group__user=user) | Q(worker_group__user=user)
             )
 
         return queryset

--- a/scripts/local.env
+++ b/scripts/local.env
@@ -9,7 +9,7 @@ DJANGO_SECRET_KEY=localdev
 DJANGO_MEDIA_ROOT=/rodan/data/
 # You can specify multiple hosts with a comma
 DJANGO_ALLOWED_HOSTS=*
-DJANGO_ADMIN_URL=admin/
+DJANGO_ADMIN_URL=^api/admin/
 IIPSRV_URL=http://localhost/fcgi-bin/iipsrv.fcgi/
 DJANGO_ACCESS_LOG=/code/Rodan/rodan.log
 DJANGO_DEBUG_LOG=/code/Rodan/database.log


### PR DESCRIPTION
Resolves: (#934)
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

This PR resolves some minor bugs caused by the django 1.11 to 2.0 migration. 
1. In django 2.0 `MIDDLEWARE_CLASSES` was changed to `MIDDLEWARE` which was causing the hard refresh issue. 
2. Users were able to see projects that they did not have permissions to see and this was resolved by filtering out projects based on permissions 
3. Updated authentication handling in the Django admin page to address an issue introduced in Django 2.0.13

