### PR TITLE
No longer fetch all user preferences

### DIFF
--- a/rodan-main/code/rodan/serializers/user.py
+++ b/rodan-main/code/rodan/serializers/user.py
@@ -27,6 +27,7 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
             "projects",
             "workflows",
             "workflow_runs",
+            "user_preference",
         )
 
 

--- a/rodan-main/code/rodan/serializers/userpreference.py
+++ b/rodan-main/code/rodan/serializers/userpreference.py
@@ -12,7 +12,7 @@ class UserPreferenceSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = UserPreference
-        fields = ("url", "user", "send_email")
+        fields = ("url", "user", "uuid", "send_email")
 
 
 class UserPreferenceListSerializer(serializers.HyperlinkedModelSerializer):


### PR DESCRIPTION
Resolves: (#460)
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

(Describe the changes you've made and the purpose of this PR)
- Add `user_preference` field in user serializer and use it to fetch user preference by id