### PR TITLE
Fix ports max 0

### DIFF
--- a/rodan-main/code/rodan/views/workflow.py
+++ b/rodan-main/code/rodan/views/workflow.py
@@ -173,7 +173,7 @@ class WorkflowDetail(generics.RetrieveUpdateDestroyAPIView):
                         ),
                         [wfjob, opt],
                     )
-                elif opt.maximum > 0: #since in the Wiki, 0 is described as there is no maximum requirement. More info here: https://github.com/DDMAL/Rodan/wiki/Write-a-Rodan-job-package#1-describe-a-rodan-job
+                elif opt.maximum != 0: #since in the Wiki, 0 is described as there is no maximum requirement. More info here: https://github.com/DDMAL/Rodan/wiki/Write-a-Rodan-job-package#1-describe-a-rodan-job
                     if number_of_output_ports > opt.maximum:
                         raise WorkflowValidationError(
                             "WFJ_TOO_MANY_OP",

--- a/rodan-main/code/rodan/views/workflow.py
+++ b/rodan-main/code/rodan/views/workflow.py
@@ -151,14 +151,15 @@ class WorkflowDetail(generics.RetrieveUpdateDestroyAPIView):
                         ),
                         [wfjob, ipt],
                     )
-                elif number_of_input_ports > ipt.maximum:
-                    raise WorkflowValidationError(
-                        "WFJ_TOO_MANY_IP",
-                        "The WorkflowJob {0} has too many InputPorts of type {1}.".format(
-                            wfjob.job_name, ipt.name
-                        ),
-                        [wfjob, ipt],
-                    )
+                elif ipt.maximum != 0: #since in the Wiki, 0 means there is no maximum requirement. More info here: https://github.com/DDMAL/Rodan/wiki/Write-a-Rodan-job-package#1-describe-a-rodan-job
+                    if number_of_input_ports > ipt.maximum:
+                        raise WorkflowValidationError(
+                            "WFJ_TOO_MANY_IP",
+                            "The WorkflowJob {0} has too many InputPorts of type {1}.".format(
+                                wfjob.job_name, ipt.name
+                            ),
+                            [wfjob, ipt],
+                        )
 
             for opt in output_port_types:
                 number_of_output_ports = wfjob.output_ports.filter(
@@ -172,14 +173,15 @@ class WorkflowDetail(generics.RetrieveUpdateDestroyAPIView):
                         ),
                         [wfjob, opt],
                     )
-                elif number_of_output_ports > opt.maximum:
-                    raise WorkflowValidationError(
-                        "WFJ_TOO_MANY_OP",
-                        "The WorkflowJob {0} has too many OutputPorts of type {1}.".format(
-                            wfjob.job_name, opt.name
-                        ),
-                        [wfjob, opt],
-                    )
+                elif opt.maximum > 0: #since in the Wiki, 0 is described as there is no maximum requirement. More info here: https://github.com/DDMAL/Rodan/wiki/Write-a-Rodan-job-package#1-describe-a-rodan-job
+                    if number_of_output_ports > opt.maximum:
+                        raise WorkflowValidationError(
+                            "WFJ_TOO_MANY_OP",
+                            "The WorkflowJob {0} has too many OutputPorts of type {1}.".format(
+                                wfjob.job_name, opt.name
+                            ),
+                            [wfjob, opt],
+                        )
 
             v = jsonschema.Draft4Validator(
                 dict(job.settings)


### PR DESCRIPTION
Resolves: (#498)
- [ ] I passed the docker hub test, and images can be built successfully.
- [ ] I passed the GitHub CI test, so rodan functionalities and jobs work.

Include if else in `workflow.py` to only check for `WFJ_TOO_MANY_IP` or `WFJ_TOO_MANY_OP` when maximum port is not set to 0. According to the [Wiki](https://github.com/DDMAL/Rodan/wiki/Write-a-Rodan-job-package#1-describe-a-rodan-job), the maximum ports of 0 indicates no maximum requirement. 