### PR TITLE
Fix end-to-end test with selenium

### DIFF
--- a/e2e/rodan_connection.py
+++ b/e2e/rodan_connection.py
@@ -192,6 +192,11 @@ class RodanConnection:
         workflow_dropdown = self.find_visible(
             By.XPATH, '//*[@id="region-main"]//*[contains(text(), "Workflow")]'
         )
+        workflow_dropdown = self.find_visible(
+            By.ID, "bs-example-navbar-collapse-1"
+        )
+        workflow_dropdown = workflow_dropdown.find_element(By.TAG_NAME, "ul")
+        workflow_dropdown = workflow_dropdown.find_element(By.TAG_NAME, "li")
         workflow_dropdown.click()
         # Click "Add Job".
         add_job_button = self.find_visible(By.ID, "button-add_job")


### PR DESCRIPTION
Resolves: #960
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

After minor UI updates last year, there are two elements with the same text (`Workflow`), so Selenium is confused.
Resolve this by searching elements by ID.