### PR TITLE
[Client] Fix error when reopening input port select resource modal

### DIFF
--- a/rodan-client/code/src/js/Controllers/ControllerResource.js
+++ b/rodan-client/code/src/js/Controllers/ControllerResource.js
@@ -173,10 +173,10 @@ export default class ControllerResource extends BaseController
     _handleCurrentResources(options)
     {
         try {
-            if (this._collection['_lastData']['project'] === options.data.project) {
+            if (this._collection_no_page['_lastData']['project'] === options.data.project) {
                 return this._collection_no_page;
             } else {
-                return this._handleRequestResources(options);
+                return this._handleRequestResourcesNoPagination(options);
             }
         } catch (e) {
             console.debug(e);


### PR DESCRIPTION
Resolves: (#977)
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

(Describe the changes you've made and the purpose of this PR)
- Check and update the correct field (`this.collection_no_page` instead of `this.collection`)