### PR TITLE
Order querysets to avoid inconsistent results warning 

### DIFF
--- a/rodan-main/code/rodan/views/job.py
+++ b/rodan-main/code/rodan/views/job.py
@@ -14,7 +14,7 @@ class JobList(generics.ListAPIView):
     """
 
     permission_classes = (permissions.AllowAny,)
-    queryset = Job.objects.all()
+    queryset = Job.objects.all().order_by('category', 'name') 
     serializer_class = JobSerializer
     pagination_class = CustomPaginationWithDisablePaginationOption
     filter_backends = (filters.DjangoFilterBackend, OrderingFilter,)
@@ -48,6 +48,6 @@ class JobDetail(generics.RetrieveAPIView):
     """
 
     permission_classes = (permissions.AllowAny,)
-    queryset = Job.objects.all()
+    queryset = Job.objects.all().order_by('name')
     serializer_class = JobSerializer
     filter_backends = ()

--- a/rodan-main/code/rodan/views/project.py
+++ b/rodan-main/code/rodan/views/project.py
@@ -39,8 +39,7 @@ class ProjectList(generics.ListCreateAPIView):
             queryset = queryset.filter(
                 Q(creator=user) | Q(admin_group__user=user) | Q(worker_group__user=user)
             )
-
-        return queryset
+        return queryset.order_by('-created')
 
     def perform_create(self, serializer):
         serializer.save(creator=self.request.user)

--- a/rodan-main/code/rodan/views/resource.py
+++ b/rodan-main/code/rodan/views/resource.py
@@ -64,7 +64,7 @@ class ResourceList(generics.ListCreateAPIView):
     """
     permission_classes = (permissions.IsAuthenticated, CustomObjectPermissions)
     _ignore_model_permissions = True
-    queryset = Resource.objects.all()
+    queryset = Resource.objects.all().order_by("-created")
     serializer_class = NestedLabelsResourceSerializer
 
     class filter_class(django_filters.FilterSet):
@@ -145,7 +145,7 @@ class ResourceList(generics.ListCreateAPIView):
             condition &= resource_list_condition
 
         # then this queryset is filtered on `filter_fields`
-        queryset = Resource.objects.filter(condition)
+        queryset = Resource.objects.filter(condition).order_by("-created")
         return queryset
 
     def paginate_queryset(self, queryset, view=None):
@@ -227,7 +227,7 @@ class ResourceDetail(generics.RetrieveUpdateDestroyAPIView):
     """
     permission_classes = (permissions.IsAuthenticated, CustomObjectPermissions, )
     _ignore_model_permissions = True
-    queryset = Resource.objects.all()
+    queryset = Resource.objects.all().order_by("-created")
     serializer_class = NestedLabelsResourceSerializer
 
     def patch(self, request, *args, **kwargs):
@@ -305,7 +305,7 @@ class ResourceViewer(APIView):
     """
     # permission_classes = (permissions.IsAuthenticated, CustomObjectPermissions, )
     _ignore_model_permissions = True
-    queryset = Resource.objects.all()
+    queryset = Resource.objects.all().order_by("-created")
     serializer_class = NestedLabelsResourceSerializer
 
     # authentication_classes = ()
@@ -350,7 +350,7 @@ class ResourceAcquireView(generics.GenericAPIView):
     lookup_url_kwarg = "resource_uuid"  # for self.get_object()
     permission_classes = (permissions.IsAuthenticated, CustomObjectPermissions, )
     _ignore_model_permissions = True
-    queryset = Resource.objects.all()
+    queryset = Resource.objects.all().order_by("-created")
 
     def get_serializer_class(self):
 
@@ -398,7 +398,7 @@ class ResourceArchive(generics.GenericAPIView):
     """
 
     permission_classes = (permissions.IsAuthenticated,)
-    queryset = Resource.objects.all()
+    queryset = Resource.objects.all().order_by("-created")
     serializer_class = NestedLabelsResourceSerializer
 
     def get(self, request, format=None):

--- a/rodan-main/code/rodan/views/runjob.py
+++ b/rodan-main/code/rodan/views/runjob.py
@@ -38,6 +38,9 @@ class RunJobList(generics.ListAPIView):
                 "resource_uuid": ["exact"],
                 "job_name": ["exact", "icontains"],
             }
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        return queryset.order_by('-created')  # Order the queryset
 
 
 class RunJobDetail(generics.RetrieveAPIView):

--- a/rodan-main/code/rodan/views/userpreference.py
+++ b/rodan-main/code/rodan/views/userpreference.py
@@ -29,9 +29,10 @@ class UserPreferenceList(generics.ListCreateAPIView):
         # a user only can view its own userpreference unless it is a superuser
         user = self.request.user
         if user.is_superuser:
-            return self.queryset
-        return UserPreference.objects.filter(user=user)
-
+            return self.queryset.order_by("user")
+        queryset = UserPreference.objects.filter(user=user)
+        return queryset.order_by("user")
+    
     def post(self, request, *args, **kwargs):
         user_url = request.data.get("user", None)
         if user_url:
@@ -65,4 +66,4 @@ class UserPreferenceDetail(generics.RetrieveUpdateDestroyAPIView):
     permission_classes = (permissions.IsAuthenticated, CustomObjectPermissions)
     _ignore_model_permissions = True
     serializer_class = UserPreferenceSerializer
-    queryset = UserPreference.objects.all()
+    queryset = UserPreference.objects.all().order_by("user")

--- a/rodan-main/code/rodan/views/workflow.py
+++ b/rodan-main/code/rodan/views/workflow.py
@@ -32,7 +32,7 @@ class WorkflowList(generics.ListCreateAPIView):
 
     permission_classes = (permissions.IsAuthenticated, CustomObjectPermissions)
     _ignore_model_permissions = True
-    queryset = Workflow.objects.all()
+    queryset = Workflow.objects.all().order_by("-created")
     serializer_class = WorkflowListSerializer
     filter_fields = {
         "updated": ["lt", "gt"],
@@ -72,7 +72,7 @@ class WorkflowDetail(generics.RetrieveUpdateDestroyAPIView):
 
     permission_classes = (permissions.IsAuthenticated, CustomObjectPermissions)
     _ignore_model_permissions = True
-    queryset = Workflow.objects.all()
+    queryset = Workflow.objects.all().order_by("-created")
     serializer_class = WorkflowSerializer
 
     def get(self, request, *a, **k):

--- a/rodan-main/code/rodan/views/workflowjobgroup.py
+++ b/rodan-main/code/rodan/views/workflowjobgroup.py
@@ -26,6 +26,10 @@ class WorkflowJobGroupList(generics.ListCreateAPIView):
     filter_fields = ("origin",)
     queryset = WorkflowJobGroup.objects.all()  # [TODO] filter according to the user?
 
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        return queryset.order_by('-created')  # Order the queryset
+
     def get_serializer_class(self, *a, **k):
         if self.request.method == "POST" and "origin" in self.request.data:
             return WorkflowJobGroupImportCreateSerializer

--- a/rodan-main/code/rodan/views/workflowrun.py
+++ b/rodan-main/code/rodan/views/workflowrun.py
@@ -73,6 +73,9 @@ class WorkflowRunList(generics.ListCreateAPIView):
         "creator__username": ["icontains"],
         "name": ["exact", "icontains"],
     }
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        return queryset.order_by('-created')  # Order the queryset
 
     def perform_create(self, serializer):
         wfrun_status = serializer.validated_data.get(


### PR DESCRIPTION
Resolves: (#982 )
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

I added some ordering for the querysets in the rodan views to prevent the filtering warnings that come up in the docker logs. I only modified the files that were throwing the warnings, there may be more filtering that needs to happen in the future