### PR TITLE
Modify IC frontend to flush grouped glyphs on save function

### DIFF
--- a/rodan-main/code/rodan/jobs/interactive_classifier/ic_frontend/public/js/app/App.js
+++ b/rodan-main/code/rodan/jobs/interactive_classifier/ic_frontend/public/js/app/App.js
@@ -292,6 +292,11 @@ var App = Marionette.Application.extend(
                 {
                     if (response.status === 200)
                     {
+                        // flush stored grouped glyphs, so they are not rewritten on future saves
+                        that.groupedGlyphs = [];
+                        
+                        // TODO: potentially flush othe stored lists here? (changed glyphs, deleted, etc.)
+
                         that.modals.saveChanges.close();
 
                     }


### PR DESCRIPTION
By resetting the array on the save event, we ensure that the same glyphs are not sent to the backend on consecutive clicks of the save button. I have run Sabrina's tests outlined in #955 as well as other tests for Revert and Reclassify, and all functionality seems to work as intended with this change.

Resolves: (#955)
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

