### PR TITLE
Add column splitting job

### DIFF
--- a/rodan-main/code/rodan/jobs/column_split/__init__.py
+++ b/rodan-main/code/rodan/jobs/column_split/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (C) 2020 Juliette Regimbal
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+__version__ = "1.0.0"
+from rodan.jobs import module_loader
+module_loader("rodan.jobs.column_split.base")

--- a/rodan-main/code/rodan/jobs/column_split/base.py
+++ b/rodan-main/code/rodan/jobs/column_split/base.py
@@ -1,5 +1,5 @@
 from rodan.jobs.base import RodanTask
-from .column_split import get_split_locations,get_split_ranges,get_stacked_image
+from .column_split import *
 import cv2 as cv
 import os
 import logging
@@ -59,13 +59,14 @@ class ColumnSplit(RodanTask):
 
     def run_my_task(self, inputs, settings, outputs):
         logger.info("Running Column Splitting")
-        splits = settings['Number of columns']
+        splits = settings['Number of columns'] - 1
         staff_layer = inputs['Staff Layer'][0]['resource_path']
         img = cv.imread(staff_layer,cv.IMREAD_UNCHANGED)
+        gray = convert_to_grayscale(img)
         logger.info("Getting split locations")
-        split_locations = get_split_locations(img,splits)
+        split_locations = get_split_locations(gray,splits)
         logger.info("Getting split ranges")
-        ranges = get_split_ranges(img,split_locations)
+        ranges = get_split_ranges(gray,split_locations)
         logger.info("Getting stacked images")
         staff_stacked = get_stacked_image(img,ranges)
         outfile = outputs['Staff Layer'][0]['resource_path']

--- a/rodan-main/code/rodan/jobs/column_split/base.py
+++ b/rodan-main/code/rodan/jobs/column_split/base.py
@@ -2,6 +2,7 @@ from rodan.jobs.base import RodanTask
 from .column_split import *
 import cv2 as cv
 import os
+import json
 import logging
 logger = logging.getLogger('rodan')
 
@@ -55,6 +56,13 @@ class ColumnSplit(RodanTask):
         {'name': 'Layer 8', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
         {'name': 'Layer 9', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
         {'name': 'Layer 10', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {
+        'name': 'Column Splitting Data',
+        'resource_types': ['application/json'],
+        'minimum': 1,
+        'maximum': 1,
+        'is_list': False
+        }
     )
 
     def run_my_task(self, inputs, settings, outputs):
@@ -110,4 +118,15 @@ class ColumnSplit(RodanTask):
                 outfile = outputs[key][0]['resource_path']
                 cv.imwrite(outfile+".png",layer_stacked)
                 os.rename(outfile+".png", outfile)
+
+        out_json_file = outputs['Column Splitting Data'][0]['resource_path']
+
+        out_json = {
+            'width': merged.shape[1],
+            'height': merged.shape[0],
+            'split_ranges': ranges,
+        }
+        with open(out_json_file, 'w') as f:
+            json.dump(out_json, f)
+
         return True

--- a/rodan-main/code/rodan/jobs/column_split/base.py
+++ b/rodan-main/code/rodan/jobs/column_split/base.py
@@ -1,6 +1,7 @@
 from rodan.jobs.base import RodanTask
 from .column_split import get_split_locations,get_split_ranges,get_stacked_image
 import cv2 as cv
+import os
 import logging
 logger = logging.getLogger('rodan')
 
@@ -60,20 +61,24 @@ class ColumnSplit(RodanTask):
         logger.info("Running Column Splitting")
         splits = settings['Number of columns']
         staff_layer = inputs['Staff Layer'][0]['resource_path']
+        img = cv.imread(staff_layer,cv.IMREAD_UNCHANGED)
         logger.info("Getting split locations")
-        split_locations = get_split_locations(staff_layer,splits)
+        split_locations = get_split_locations(img,splits)
         logger.info("Getting split ranges")
-        ranges = get_split_ranges(split_locations)
+        ranges = get_split_ranges(img,split_locations)
         logger.info("Getting stacked images")
-        staff_stacked = get_stacked_image(staff_layer,ranges)
+        staff_stacked = get_stacked_image(img,ranges)
         outfile = outputs['Staff Layer'][0]['resource_path']
-        cv.imwrite(outfile,staff_stacked)
+        cv.imwrite(outfile+".png",staff_stacked)
+        os.rename(outfile+".png", outfile)
 
         for key in inputs:
             if key != 'Staff Layer':
-                layer = inputs
+                layer = inputs[key][0]['resource_path']
+                img = cv.imread(layer,cv.IMREAD_UNCHANGED)
                 logger.info("Getting stacked images")
-                layer_stacked = get_stacked_image(layer,ranges)
+                layer_stacked = get_stacked_image(img,ranges)
                 outfile = outputs[key][0]['resource_path']
-                cv.imwrite(outfile,layer_stacked)
+                cv.imwrite(outfile+".png",layer_stacked)
+                os.rename(outfile+".png", outfile)
         return True

--- a/rodan-main/code/rodan/jobs/column_split/base.py
+++ b/rodan-main/code/rodan/jobs/column_split/base.py
@@ -1,0 +1,79 @@
+from rodan.jobs.base import RodanTask
+from .column_split import get_split_locations,get_split_ranges,get_stacked_image
+import cv2 as cv
+import logging
+logger = logging.getLogger('rodan')
+
+class ColumnSplit(RodanTask):
+    name = 'Column Splitting'
+    author = 'Anthony Tan'
+    description = 'Finds the locations of the columns of a folio based on the staff layers then stacks them into a single image.'
+    enabled = True
+    category = 'OMR - Layout analysis'
+    interactive = False
+
+    settings = {
+        'title': 'Settings',
+        'type': 'object',
+        'job_queue': 'Python3',
+        'required': ['Number of columns'],
+        'properties': {
+            'Number of columns': {
+                'type': 'integer',
+                'default': 2,
+                'minimum': 2,
+                'maximum': 10,
+                'description': 'Number of columns in the folio. Must be at least 2. If there is only one, don\'t use this job.'
+            }
+        }
+    }
+
+    input_port_types = (
+        {'name': 'Staff Layer', 'minimum': 1, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Background Layer', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Music Notes Layer', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Text Layer', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Layer 4', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Layer 5', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Layer 6', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Layer 7', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Layer 8', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Layer 9', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Layer 10', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+    )
+
+    output_port_types = (
+        {'name': 'Staff Layer', 'minimum': 1, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Background Layer', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Music Notes Layer', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Text Layer', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Layer 4', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Layer 5', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Layer 6', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Layer 7', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Layer 8', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Layer 9', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Layer 10', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+    )
+
+    def run_my_task(self, inputs, settings, outputs):
+        logger.info("Running Column Splitting")
+        splits = settings['Number of columns']
+        staff_layer = inputs['Staff Layer'][0]['resource_path']
+        logger.info("Getting split locations")
+        split_locations = get_split_locations(staff_layer,splits)
+        logger.info("Getting split ranges")
+        ranges = get_split_ranges(split_locations)
+        logger.info("Getting stacked images")
+        staff_stacked = get_stacked_image(staff_layer,ranges)
+        outfile = outputs['Staff Layer'][0]['resource_path']
+        cv.imwrite(outfile,staff_stacked)
+
+        for key in inputs:
+            if key != 'Staff Layer':
+                layer = inputs
+                logger.info("Getting stacked images")
+                layer_stacked = get_stacked_image(layer,ranges)
+                outfile = outputs[key][0]['resource_path']
+                cv.imwrite(outfile,layer_stacked)
+        return True

--- a/rodan-main/code/rodan/jobs/column_split/base.py
+++ b/rodan-main/code/rodan/jobs/column_split/base.py
@@ -32,8 +32,8 @@ class ColumnSplit(RodanTask):
     input_port_types = (
         {'name': 'Staff Layer', 'minimum': 1, 'maximum': 1, 'resource_types': ['image/rgba+png']},
         {'name': 'Background Layer', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
-        {'name': 'Music Notes Layer', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
-        {'name': 'Text Layer', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Music Notes Layer', 'minimum': 1, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Text Layer', 'minimum': 1, 'maximum': 1, 'resource_types': ['image/rgba+png']},
         {'name': 'Layer 4', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
         {'name': 'Layer 5', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
         {'name': 'Layer 6', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
@@ -46,8 +46,8 @@ class ColumnSplit(RodanTask):
     output_port_types = (
         {'name': 'Staff Layer', 'minimum': 1, 'maximum': 1, 'resource_types': ['image/rgba+png']},
         {'name': 'Background Layer', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
-        {'name': 'Music Notes Layer', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
-        {'name': 'Text Layer', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Music Notes Layer', 'minimum': 1, 'maximum': 1, 'resource_types': ['image/rgba+png']},
+        {'name': 'Text Layer', 'minimum': 1, 'maximum': 1, 'resource_types': ['image/rgba+png']},
         {'name': 'Layer 4', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
         {'name': 'Layer 5', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
         {'name': 'Layer 6', 'minimum': 0, 'maximum': 1, 'resource_types': ['image/rgba+png']},
@@ -60,21 +60,49 @@ class ColumnSplit(RodanTask):
     def run_my_task(self, inputs, settings, outputs):
         logger.info("Running Column Splitting")
         splits = settings['Number of columns'] - 1
-        staff_layer = inputs['Staff Layer'][0]['resource_path']
-        img = cv.imread(staff_layer,cv.IMREAD_UNCHANGED)
-        gray = convert_to_grayscale(img)
-        logger.info("Getting split locations")
-        split_locations = get_split_locations(gray,splits)
-        logger.info("Getting split ranges")
-        ranges = get_split_ranges(gray,split_locations)
-        logger.info("Getting stacked images")
-        staff_stacked = get_stacked_image(img,ranges)
-        outfile = outputs['Staff Layer'][0]['resource_path']
-        cv.imwrite(outfile+".png",staff_stacked)
-        os.rename(outfile+".png", outfile)
 
+        staff_layer = inputs['Staff Layer'][0]['resource_path']
+        text_layer = inputs['Text Layer'][0]['resource_path']
+        neume_layer = inputs['Music Notes Layer'][0]['resource_path']
+
+        staff = cv.imread(staff_layer,cv.IMREAD_UNCHANGED)
+        text = cv.imread(text_layer,cv.IMREAD_UNCHANGED)
+        neume = cv.imread(neume_layer,cv.IMREAD_UNCHANGED)
+
+        gray_text = convert_to_grayscale(text) == False
+        gray_staff = convert_to_grayscale(staff) == False
+        gray_neume = convert_to_grayscale(neume) == False
+        
+        logger.info("Merging the three layers")
+        merged = get_merged_layers([gray_text,gray_staff,gray_neume])
+        logger.info("Getting split locations")
+        split_locations = get_split_locations(merged,splits)
+        logger.info("Getting split ranges")
+        ranges = get_split_ranges(merged,split_locations)
+        logger.info("Getting stacked images")
+        
+        stacked_text = get_stacked_image(text,ranges)
+        stacked_staff = get_stacked_image(staff,ranges)
+        stacked_neume = get_stacked_image(neume,ranges)
+            # save stacked images
+        cv.imwrite('test_data/2-text-stacked.png',stacked_text)
+        cv.imwrite('test_data/2-staff-stacked.png',stacked_staff)
+        cv.imwrite('test_data/2-neume-stacked.png',stacked_neume)
+
+        outfile_staff = outputs['Staff Layer'][0]['resource_path']
+        cv.imwrite(outfile_staff+".png",stacked_staff)
+        os.rename(outfile_staff+".png", outfile_staff)
+
+        outfile_text = outputs['Text Layer'][0]['resource_path']
+        cv.imwrite(outfile_text+".png",stacked_text)
+        os.rename(outfile_text+".png", outfile_text)
+
+        outfile_neume = outputs['Music Notes Layer'][0]['resource_path']
+        cv.imwrite(outfile_neume+".png",stacked_neume)
+        os.rename(outfile_neume+".png", outfile_neume)
+        
         for key in inputs:
-            if key != 'Staff Layer':
+            if key != 'Staff Layer' and key != 'Text Layer' and key != 'Music Notes Layer':
                 layer = inputs[key][0]['resource_path']
                 img = cv.imread(layer,cv.IMREAD_UNCHANGED)
                 logger.info("Getting stacked images")

--- a/rodan-main/code/rodan/jobs/column_split/base.py
+++ b/rodan-main/code/rodan/jobs/column_split/base.py
@@ -92,10 +92,7 @@ class ColumnSplit(RodanTask):
         stacked_text = get_stacked_image(text,ranges)
         stacked_staff = get_stacked_image(staff,ranges)
         stacked_neume = get_stacked_image(neume,ranges)
-            # save stacked images
-        # cv.imwrite('test_data/2-text-stacked.png',stacked_text)
-        # cv.imwrite('test_data/2-staff-stacked.png',stacked_staff)
-        # cv.imwrite('test_data/2-neume-stacked.png',stacked_neume)
+
 
         outfile_staff = outputs['Staff Layer'][0]['resource_path']
         cv.imwrite(outfile_staff+".png",stacked_staff)

--- a/rodan-main/code/rodan/jobs/column_split/base.py
+++ b/rodan-main/code/rodan/jobs/column_split/base.py
@@ -59,7 +59,7 @@ class ColumnSplit(RodanTask):
 
     def run_my_task(self, inputs, settings, outputs):
         logger.info("Running Column Splitting")
-        splits = settings['Number of columns'] - 1
+        num_columns = settings['Number of columns']
 
         staff_layer = inputs['Staff Layer'][0]['resource_path']
         text_layer = inputs['Text Layer'][0]['resource_path']
@@ -76,7 +76,7 @@ class ColumnSplit(RodanTask):
         logger.info("Merging the three layers")
         merged = get_merged_layers([gray_text,gray_staff,gray_neume])
         logger.info("Getting split locations")
-        split_locations = get_split_locations(merged,splits)
+        split_locations = get_split_locations(merged,num_columns)
         logger.info("Getting split ranges")
         ranges = get_split_ranges(merged,split_locations)
         logger.info("Getting stacked images")
@@ -85,9 +85,9 @@ class ColumnSplit(RodanTask):
         stacked_staff = get_stacked_image(staff,ranges)
         stacked_neume = get_stacked_image(neume,ranges)
             # save stacked images
-        cv.imwrite('test_data/2-text-stacked.png',stacked_text)
-        cv.imwrite('test_data/2-staff-stacked.png',stacked_staff)
-        cv.imwrite('test_data/2-neume-stacked.png',stacked_neume)
+        # cv.imwrite('test_data/2-text-stacked.png',stacked_text)
+        # cv.imwrite('test_data/2-staff-stacked.png',stacked_staff)
+        # cv.imwrite('test_data/2-neume-stacked.png',stacked_neume)
 
         outfile_staff = outputs['Staff Layer'][0]['resource_path']
         cv.imwrite(outfile_staff+".png",stacked_staff)

--- a/rodan-main/code/rodan/jobs/column_split/column_split.py
+++ b/rodan-main/code/rodan/jobs/column_split/column_split.py
@@ -73,7 +73,7 @@ def get_stacked_image(img,ranges):
             max = chunks[-1].shape[1]
     output = []
     for chunk in chunks:
-        output.append(np.pad(chunk,((0,0),(0,max-chunk.shape[1]),(0,0)),mode='constant'))
+        output.append(np.pad(chunk,((0,0),(0,max-chunk.shape[1]),(0,0)),mode='constant',constant_values=255))
     return np.vstack(output)
 
     

--- a/rodan-main/code/rodan/jobs/column_split/column_split.py
+++ b/rodan-main/code/rodan/jobs/column_split/column_split.py
@@ -1,6 +1,5 @@
 import cv2 as cv
 import numpy as np
-# from matplotlib import pyplot as plt
 
 # converts 4 channel rgba image to grayscale
 def convert_to_grayscale(img):    
@@ -43,17 +42,10 @@ def get_split_locations(gray,num_columns):
     projection = np.sum(gray,axis=0)
     # apply filter to projection
     # not sure if this is necessary
-    # plt.plot(projection,color='blue')
     filtered = moving_avg_filter(projection,filter_size=30)
     rooted = np.sqrt(filtered + 1)
-    # plt.plot(rooted * np.max(filtered)/np.max(rooted),color='orange')
     normed = rooted / np.max(rooted)
     signal = normed > 0.5
-    normed_filtered = signal * np.max(filtered)
-    # plt.plot(signal * np.max(filtered),color='green')
-    # plot the projection and save
-    # plt.plot(filtered,color='red')
-    
 
 
     i = 0
@@ -87,12 +79,7 @@ def get_split_locations(gray,num_columns):
     splits = []
     for i in range(len(bounds)-1):
         mid = (bounds[i][1] + bounds[i+1][0]) // 2
-        # plt.axvline(x=mid,color='black')
         splits.append(mid)
-
-    
-    # plt.savefig('test_data/2-projection.png')
-
 
     return splits
 
@@ -123,27 +110,3 @@ def get_stacked_image(img,ranges):
         output.append(np.pad(chunk,((0,0),(0,max-chunk.shape[1]),(0,0)),mode='constant',constant_values=255))
     # stack and return
     return np.vstack(output)
-
-if __name__ == "__main__":
-    # read image
-    text = cv.imread('test_data/2-text.png',cv.IMREAD_UNCHANGED)
-    staff = cv.imread('test_data/2-staff.png',cv.IMREAD_UNCHANGED)
-    neume = cv.imread('test_data/2-neume.png',cv.IMREAD_UNCHANGED)
-    # convert to grayscale
-    gray_text = convert_to_grayscale(text) == False
-    gray_staff = convert_to_grayscale(staff) == False
-    gray_neume = convert_to_grayscale(neume) == False
-    # merge layers
-    merged = get_merged_layers([gray_text,gray_staff,gray_neume])
-    # get split locations
-    splits = get_split_locations(merged,3)
-    # get split ranges
-    ranges = get_split_ranges(merged,splits)
-    # get stacked image
-    stacked_text = get_stacked_image(text,ranges)
-    stacked_staff = get_stacked_image(staff,ranges)
-    stacked_neume = get_stacked_image(neume,ranges)
-    # save stacked images
-    cv.imwrite('test_data/2-text-stacked.png',stacked_text)
-    cv.imwrite('test_data/2-staff-stacked.png',stacked_staff)
-    cv.imwrite('test_data/2-neume-stacked.png',stacked_neume)

--- a/rodan-main/code/rodan/jobs/column_split/column_split.py
+++ b/rodan-main/code/rodan/jobs/column_split/column_split.py
@@ -1,5 +1,6 @@
 import cv2 as cv
 import numpy as np
+# from matplotlib import pyplot as plt
 
 # converts 4 channel rgba image to grayscale
 def convert_to_grayscale(img):    
@@ -37,16 +38,22 @@ def moving_avg_filter(data, filter_size):
         smoothed[n] = np.mean(vals)
     return smoothed
 
-def get_split_locations(gray,num_splits):
+def get_split_locations(gray,num_columns):
     # invert colors to make math easier
     projection = np.sum(gray,axis=0)
     # apply filter to projection
     # not sure if this is necessary
+    # plt.plot(projection,color='blue')
     filtered = moving_avg_filter(projection,filter_size=30)
     rooted = np.sqrt(filtered + 1)
     # plt.plot(rooted * np.max(filtered)/np.max(rooted),color='orange')
     normed = rooted / np.max(rooted)
     signal = normed > 0.5
+    normed_filtered = signal * np.max(filtered)
+    # plt.plot(signal * np.max(filtered),color='green')
+    # plot the projection and save
+    # plt.plot(filtered,color='red')
+    
 
 
     i = 0
@@ -62,6 +69,10 @@ def get_split_locations(gray,num_splits):
             bounds.append((start,end))
     
     # sort column bounds in left to right order
+
+    bounds.sort(key=lambda x: -(x[1] - x[0]))
+    bounds = bounds[:num_columns]
+
     bounds.sort(key=lambda x: x[0])
 
     # make sure no bounds overlap
@@ -76,9 +87,11 @@ def get_split_locations(gray,num_splits):
     splits = []
     for i in range(len(bounds)-1):
         mid = (bounds[i][1] + bounds[i+1][0]) // 2
+        # plt.axvline(x=mid,color='black')
         splits.append(mid)
 
     
+    # plt.savefig('test_data/2-projection.png')
 
 
     return splits
@@ -110,3 +123,27 @@ def get_stacked_image(img,ranges):
         output.append(np.pad(chunk,((0,0),(0,max-chunk.shape[1]),(0,0)),mode='constant',constant_values=255))
     # stack and return
     return np.vstack(output)
+
+if __name__ == "__main__":
+    # read image
+    text = cv.imread('test_data/2-text.png',cv.IMREAD_UNCHANGED)
+    staff = cv.imread('test_data/2-staff.png',cv.IMREAD_UNCHANGED)
+    neume = cv.imread('test_data/2-neume.png',cv.IMREAD_UNCHANGED)
+    # convert to grayscale
+    gray_text = convert_to_grayscale(text) == False
+    gray_staff = convert_to_grayscale(staff) == False
+    gray_neume = convert_to_grayscale(neume) == False
+    # merge layers
+    merged = get_merged_layers([gray_text,gray_staff,gray_neume])
+    # get split locations
+    splits = get_split_locations(merged,3)
+    # get split ranges
+    ranges = get_split_ranges(merged,splits)
+    # get stacked image
+    stacked_text = get_stacked_image(text,ranges)
+    stacked_staff = get_stacked_image(staff,ranges)
+    stacked_neume = get_stacked_image(neume,ranges)
+    # save stacked images
+    cv.imwrite('test_data/2-text-stacked.png',stacked_text)
+    cv.imwrite('test_data/2-staff-stacked.png',stacked_staff)
+    cv.imwrite('test_data/2-neume-stacked.png',stacked_neume)

--- a/rodan-main/code/rodan/jobs/column_split/column_split.py
+++ b/rodan-main/code/rodan/jobs/column_split/column_split.py
@@ -1,0 +1,90 @@
+import cv2 as cv
+import numpy as np
+from matplotlib import pyplot as plt
+
+def convert_to_grayscale(img):    
+    img_gray = 255 - img[:, :, 3]
+    # save img to disk for debugging
+    return img_gray
+
+def moving_avg_filter(data, filter_size):
+    """
+    returns a list containing the data in @data filtered through a moving-average filter of size
+    @filter_size to either side; that is, filter_size = 1 gives a size of 3, filter size = 2 gives
+    a size of 5, and so on.
+
+    Ideally, filter_size should be about half the height of a letter on the page (not counting ascenders
+    or descenders), in pixels.
+    """
+    filter_size = int(filter_size)
+    smoothed = np.zeros(len(data))
+    for n in range(filter_size, len(data) - filter_size):
+        vals = data[n - filter_size : n + filter_size + 1]
+        smoothed[n] = np.mean(vals)
+    return smoothed
+
+def get_split_locations(gray,num_splits):
+    projection = np.sum(gray,axis=0)
+    filtered = moving_avg_filter(projection,filter_size=5)
+    copy = filtered.copy()
+    bounds = []
+    for i in range(num_splits+1):
+        max = np.argmax(filtered)
+        left_bound, right_bound = max, max
+        while filtered[left_bound] > 0:
+            left_bound -= 1
+        while filtered[right_bound] > 0:
+            right_bound += 1
+        bounds.append((left_bound,right_bound))
+        filtered[left_bound:right_bound + 1] = 0
+        # plt.axvline(x=left_bound,color='r')
+        # plt.axvline(x=right_bound,color='r')
+    
+
+    bounds.sort(key=lambda x: x[0])
+
+    for i in range(len(bounds)-1):
+        if bounds[i][1] > bounds[i+1][0]:
+            bounds[i][1], bounds[i+1][0] = bounds[i+1][0], bounds[i][1]
+
+    splits = []
+    for i in range(len(bounds) -1):
+        mid = (bounds[i][1] + bounds[i+1][0]) // 2
+        splits.append(mid)
+        plt.axvline(x=mid,color='g')
+
+    plt.plot(copy)
+    plt.savefig('projection.png')
+    return splits
+
+def get_split_ranges(img,splits):
+    ranges = [(0,splits[0])]
+    for split in splits[1:]:
+        ranges.append((ranges[-1][1],split))
+    ranges.append((splits[-1],img.shape[1]))
+    return ranges
+
+def get_stacked_image(img,ranges):
+    print(img.shape)
+    chunks = []
+    max = 0
+    for r in ranges:
+        chunks.append(img[:,r[0]:r[1]])
+        if chunks[-1].shape[1] > max:
+            max = chunks[-1].shape[1]
+    output = []
+    for chunk in chunks:
+        output.append(np.pad(chunk,((0,0),(0,max-chunk.shape[1]),(0,0)),mode='constant',constant_values=255))
+    return np.vstack(output)
+
+    
+
+
+if __name__ == '__main__':
+    img = cv.imread("staffs.png",cv.IMREAD_UNCHANGED)
+    gray = convert_to_grayscale(img)
+    splits = get_split_locations(gray==False,3)
+    ranges = get_split_ranges(img,splits)
+    color = cv.imread("resized.png")
+    stacked = get_stacked_image(color,ranges)
+    cv.imwrite('stacked.png',stacked)

--- a/rodan-main/code/rodan/jobs/column_split/column_split.py
+++ b/rodan-main/code/rodan/jobs/column_split/column_split.py
@@ -86,6 +86,9 @@ def get_split_locations(gray,num_columns):
 
 # gets the ranges of the original image that correspond to the columns
 def get_split_ranges(img,splits):
+    if len(splits) == 0:
+        return [(0,img.shape[1])]
+    
     ranges = [(0,splits[0])]
     for split in splits[1:]:
         ranges.append((ranges[-1][1],split))

--- a/rodan-main/code/rodan/jobs/column_split/column_split.py
+++ b/rodan-main/code/rodan/jobs/column_split/column_split.py
@@ -24,7 +24,8 @@ def moving_avg_filter(data, filter_size):
     return smoothed
 
 def get_split_locations(gray,num_splits):
-    projection = np.sum(gray,axis=0)
+    flipped = gray == False
+    projection = np.sum(flipped,axis=0)
     filtered = moving_avg_filter(projection,filter_size=5)
     copy = filtered.copy()
     bounds = []
@@ -74,7 +75,7 @@ def get_stacked_image(img,ranges):
             max = chunks[-1].shape[1]
     output = []
     for chunk in chunks:
-        output.append(np.pad(chunk,((0,0),(0,max-chunk.shape[1]),(0,0)),mode='constant',constant_values=255))
+        output.append(np.pad(chunk,((0,0),(0,max-chunk.shape[1]),(0,0)),mode='constant'))
     return np.vstack(output)
 
     
@@ -83,8 +84,8 @@ def get_stacked_image(img,ranges):
 if __name__ == '__main__':
     img = cv.imread("staffs.png",cv.IMREAD_UNCHANGED)
     gray = convert_to_grayscale(img)
-    splits = get_split_locations(gray==False,3)
+    splits = get_split_locations(gray,3)
     ranges = get_split_ranges(img,splits)
     color = cv.imread("resized.png")
-    stacked = get_stacked_image(color,ranges)
+    stacked = get_stacked_image(img,ranges)
     cv.imwrite('stacked.png',stacked)

--- a/rodan-main/code/rodan/jobs/column_split/column_split.py
+++ b/rodan-main/code/rodan/jobs/column_split/column_split.py
@@ -1,6 +1,5 @@
 import cv2 as cv
 import numpy as np
-from matplotlib import pyplot as plt
 
 def convert_to_grayscale(img):    
     img_gray = 255 - img[:, :, 3]
@@ -52,10 +51,10 @@ def get_split_locations(gray,num_splits):
     for i in range(len(bounds) -1):
         mid = (bounds[i][1] + bounds[i+1][0]) // 2
         splits.append(mid)
-        plt.axvline(x=mid,color='g')
+    #     plt.axvline(x=mid,color='g')
 
-    plt.plot(copy)
-    plt.savefig('projection.png')
+    # plt.plot(copy)
+    # plt.savefig('projection.png')
     return splits
 
 def get_split_ranges(img,splits):
@@ -66,7 +65,6 @@ def get_split_ranges(img,splits):
     return ranges
 
 def get_stacked_image(img,ranges):
-    print(img.shape)
     chunks = []
     max = 0
     for r in ranges:

--- a/rodan-main/code/rodan/registerJobs.yaml
+++ b/rodan-main/code/rodan/registerJobs.yaml
@@ -127,6 +127,12 @@
         "rodan.jobs.pixel_wrapper.wrapper": [ 
           "PixelInteractive"
           ]
+    },
+
+    "rodan.jobs.column_split": {
+        "rodan.jobs.column_split.base": [ 
+          "ColumnSplit"
+          ]
     }
       
     }


### PR DESCRIPTION
Resolves: (#ID-of-the-issue)
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

Implements a job when given a folio with multiple columns and the output from Paco's, it returns new layers with the columns stack. Addresses https://github.com/DDMAL/Rodan/issues/828. Tested on [Tours, F-TOm 149](https://cantus.simssa.ca/manuscript/146/).

The algorithm uses the vertical projection of the staff layer. It works as follows: for i in the range of columns: find the highest point on the projection. Find the points to the left and right with value 0. Consider that a column and remove it from the projection. After finding the column ranges, split them up then stack them.

This has been tested on 10 folios from Tours, F-TOm 149](https://cantus.simssa.ca/manuscript/146/), all of which worked really well. Here are some example layers from different folios.

![0023](https://github.com/DDMAL/Rodan/assets/57821698/a7028724-f007-4741-9319-d10e7c8bb394)
![0029](https://github.com/DDMAL/Rodan/assets/57821698/c7d61f9c-ec8b-4324-be51-915af3d9f138)
![0033](https://github.com/DDMAL/Rodan/assets/57821698/983b2775-c89c-4d94-997f-73217694a106)

Note that the messy layers is due to using a Salzinnes model on a different folio