### PR TITLE
Fix #1005, Change cuda to 11.2.2

### DIFF
--- a/gpu-celery/Dockerfile
+++ b/gpu-celery/Dockerfile
@@ -21,7 +21,7 @@
 
 ARG UBUNTU_VERSION=18.04
 ARG CUDA=11.2
-FROM nvidia/cuda${ARCH:+-$ARCH}:${CUDA}.1-base-ubuntu${UBUNTU_VERSION} as base
+FROM nvidia/cuda${ARCH:+-$ARCH}:${CUDA}.2-base-ubuntu${UBUNTU_VERSION} as base
 # ARCH and CUDA are specified again because the FROM directive resets ARGs
 # (but their default value is retained if set previously)
 ARG ARCH


### PR DESCRIPTION
Resolves: #1005
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

cuda 11.2.1 is no longer supported. Upgrade to cuda 11.2.2