### PR TITLE
Delete generated resources when workflow run is deleted

### DIFF
--- a/rodan-client/code/src/js/Views/Master/Dialog/ViewConfirmationDialog.js
+++ b/rodan-client/code/src/js/Views/Master/Dialog/ViewConfirmationDialog.js
@@ -1,0 +1,54 @@
+import $ from 'jquery';
+import _ from 'underscore';
+import RODAN_EVENTS from 'js/Shared/RODAN_EVENTS';
+import Marionette from 'backbone.marionette';
+import Radio from 'backbone.radio';
+
+/**
+ * Password view.
+ */
+export default class ViewConfirmationDialog extends Marionette.CollectionView
+{
+    initialize(options)
+    {
+        this._message = options.message;
+        this._onConfirm = options.onConfirm;
+    }
+
+    templateContext()
+    {
+        return {
+            message: this._message
+        };
+    }
+
+///////////////////////////////////////////////////////////////////////////////////////
+// PRIVATE METHODS
+///////////////////////////////////////////////////////////////////////////////////////
+    _handleButtonConfirm()
+    {
+        this._onConfirm();
+    }
+
+    _handleButtonCancel()
+    {
+        Radio.channel("rodan").request(RODAN_EVENTS.REQUEST__MODAL_HIDE);
+    }
+    
+}
+
+ViewConfirmationDialog.prototype.modelEvents = {
+            'all': 'render'
+        };
+
+ViewConfirmationDialog.prototype.ui = {
+            buttonConfirm: '#button-confirm',
+            buttonCancel: '#button-cancel'
+        };
+
+ViewConfirmationDialog.prototype.events = {
+            'click @ui.buttonConfirm': '_handleButtonConfirm',
+            'click @ui.buttonCancel': '_handleButtonCancel'
+        };
+
+ViewConfirmationDialog.prototype.template = _.template($('#template-dialog_confirm').text());

--- a/rodan-client/code/src/js/Views/Master/Main/WorkflowRun/Individual/LayoutViewIndividualWorkflowRun.js
+++ b/rodan-client/code/src/js/Views/Master/Main/WorkflowRun/Individual/LayoutViewIndividualWorkflowRun.js
@@ -8,6 +8,7 @@ import ViewResourceCollection from 'js/Views/Master/Main/Resource/Collection/Vie
 import ViewResourceCollectionItem from 'js/Views/Master/Main/Resource/Collection/ViewResourceCollectionItem';
 import ViewRunJobCollection from 'js/Views/Master/Main/RunJob/Collection/ViewRunJobCollection';
 import ViewRunJobCollectionItem from 'js/Views/Master/Main/RunJob/Collection/ViewRunJobCollectionItem';
+import ViewConfirmationDialog from '../../../Dialog/ViewConfirmationDialog';
 
 /**
  * WorkflowRun view.
@@ -113,7 +114,11 @@ export default class LayoutViewIndividualWorkflowRun extends Marionette.View
      */
     _handleButtonDelete()
     {
-        Radio.channel('rodan').request(RODAN_EVENTS.REQUEST__WORKFLOWRUN_DELETE, {workflowrun: this.model});
+        const content = new ViewConfirmationDialog({
+            message: 'Are you sure you want to delete this WorkflowRun? This will delete all related Run Jobs and Resources.',
+            onConfirm: () => Radio.channel('rodan').request(RODAN_EVENTS.REQUEST__WORKFLOWRUN_DELETE, { workflowrun: this.model }),
+        });
+        Radio.channel('rodan').request(RODAN_EVENTS.REQUEST__MODAL_SHOW, { title: 'Delete WorkflowRun', content });
     }
 }
 LayoutViewIndividualWorkflowRun.prototype.modelEvents = {

--- a/rodan-client/code/templates/Views/Master/Main/Dialog/template-dialog_confirm.html
+++ b/rodan-client/code/templates/Views/Master/Main/Dialog/template-dialog_confirm.html
@@ -1,0 +1,6 @@
+<div class="fixed_individual">
+    <p><%- message %></p>
+    <br>
+    <button class="btn btn-xs btn-warning" id="button-cancel">Cancel</button>
+    <button class="btn btn-xs btn-danger" id="button-confirm">Confirm</button>
+</div>


### PR DESCRIPTION
Resolves: (#996)
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

(Describe the changes you've made and the purpose of this PR)
- Add post_delete listener to delete resources when their associated workflow run is deleted
- Show confirmation dialog when users are deleting a workflow run