### PR TITLE
Enable retrying failed/cancelled workflow runs

### DIFF
--- a/rodan-client/code/src/js/Shared/RODAN_EVENTS.js
+++ b/rodan-client/code/src/js/Shared/RODAN_EVENTS.js
@@ -512,6 +512,8 @@ class RODAN_EVENTS
         this.EVENT__WORKFLOWRUN_SAVED = 'EVENT__WORKFLOWRUN_SAVED';
         /** Triggered when WorkflowRun started. Sends {workflowrun: WorkflowRun}. */
         this.EVENT__WORKFLOWRUN_STARTED = 'EVENT__WORKFLOWRUN_STARTED';
+        /** Triggered when WorkflowRun retried. Sends {workflowrun: WorkflowRun}. */
+        this.EVENT__WORKFLOWRUN_RETRIED = 'EVENT__WORKFLOWRUN_RETRIED';
         /** Triggered when the user selects an individual WorkflowRun. Sends {workflow: WorkflowRun}. */
         this.EVENT__WORKFLOWRUN_SELECTED = 'EVENT__WORKFLOWRUN_SELECTED';
         /** Triggered when the user selects to see all available WorkflowRuns. Sends {project: Project (Project associated with WorkflowRunCollection)}. */
@@ -524,6 +526,8 @@ class RODAN_EVENTS
         this.REQUEST__WORKFLOWRUN_SAVE = 'REQUEST__WORKFLOWRUN_SAVE';
         /** Request a WorkflowRun be started. Takes {model: WorkflowRun}. */
         this.REQUEST__WORKFLOWRUN_START = 'REQUEST__WORKFLOWRUN_START';
+        /** Request a failed or cancelled WorkflowRun be retried. Takes {model: WorkflowRun}. */
+        this.REQUEST__WORKFLOWRUN_RETRY = 'REQUEST__WORKFLOWRUN_RETRY';
 
         ///////////////////////////////////////////////////////////////////////////////////////
         // VERSION COMPATIBILITY CHECKS

--- a/rodan-client/code/src/js/Views/Master/Main/WorkflowRun/Individual/LayoutViewIndividualWorkflowRun.js
+++ b/rodan-client/code/src/js/Views/Master/Main/WorkflowRun/Individual/LayoutViewIndividualWorkflowRun.js
@@ -115,6 +115,14 @@ export default class LayoutViewIndividualWorkflowRun extends Marionette.View
     {
         Radio.channel('rodan').request(RODAN_EVENTS.REQUEST__WORKFLOWRUN_DELETE, {workflowrun: this.model});
     }
+
+    /**
+     * Handle retry button.
+     */
+    _handleButtonRetry()
+    {
+        Radio.channel('rodan').request(RODAN_EVENTS.REQUEST__WORKFLOWRUN_RETRY, {workflowrun: this.model});
+    }
 }
 LayoutViewIndividualWorkflowRun.prototype.modelEvents = {
     'all': 'render'
@@ -124,6 +132,7 @@ LayoutViewIndividualWorkflowRun.prototype.ui = {
     buttonShowRunJobs: '#button-runjobs_show',
     buttonSave: '#button-save_workflowrun',
     buttonDelete: '#button-delete_workflowrun',
+    buttonRetry: '#button-retry_workflowrun',
     textName: '#text-workflowrun_name',
     textDescription: '#text-workflowrun_description'
 };
@@ -131,7 +140,7 @@ LayoutViewIndividualWorkflowRun.prototype.events = {
     'click @ui.buttonShowResources': '_showResources',
     'click @ui.buttonShowRunJobs': '_showRunJobs',
     'click @ui.buttonSave': '_handleButtonSave',
-    'click @ui.buttonDelete': '_handleButtonDelete'
-
+    'click @ui.buttonDelete': '_handleButtonDelete',
+    'click @ui.buttonRetry': '_handleButtonRetry',
 };
 LayoutViewIndividualWorkflowRun.prototype.template = _.template($('#template-main_workflowrun_individual').text());

--- a/rodan-client/code/templates/Views/Master/Main/WorkflowRun/Individual/template-main_workflowrun_individual.html
+++ b/rodan-client/code/templates/Views/Master/Main/WorkflowRun/Individual/template-main_workflowrun_individual.html
@@ -10,6 +10,9 @@
         Updated on: <%= _.formatFromUTC(updated) %><br/>
         URL: <%= url %><br>
         Status: <%= statusText %><br/>
+        <% if (status === -1 || status === 9) { %>
+            <button class="btn btn-xs btn-warning" id="button-retry_workflowrun">Retry</button>
+        <% } %>
         <button class="btn btn-xs btn-warning" id="button-save_workflowrun">Save</button>
         <button class="btn btn-xs btn-danger" id="button-delete_workflowrun">Delete</button>
     </div>


### PR DESCRIPTION
Resolves: (#1008)
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

(Describe the changes you've made and the purpose of this PR)
- When a `WorkflowRun` fails, there is now a retry button that will reschedule failed/cancelled jobs