### PR TITLE
Upgrade pillow

### DIFF
--- a/rodan-main/code/requirements.txt
+++ b/rodan-main/code/requirements.txt
@@ -25,7 +25,7 @@ numpy==1.17.3
 model-mommy==1.6.0
 pathlib2==2.3.6
 pika==1.1.0
-pillow==8.2.0
+pillow==8.3.2
 protobuf==3.17.3
 psycopg2==2.8.4
 -e git+https://github.com/deepio/pybagit.git@4eea813148bc590896000f57cde35fb86443d2f4#egg=pybagit ; python_version >= '3.0'


### PR DESCRIPTION
Resolves: 
- [ ] I passed the docker hub test, and images can be built successfully.
- [ ] I passed the GitHub CI test, so rodan functionalities and jobs work.

The gpu container uses pillow 8.3.2 so I am upgrading the pillow version used for python3 jobs to match this. 