### PR TITLE
change default text alignment model to newest

### DIFF
--- a/rodan-main/code/rodan/jobs/text_alignment/text_alignment.py
+++ b/rodan-main/code/rodan/jobs/text_alignment/text_alignment.py
@@ -31,7 +31,7 @@ class text_alignment(RodanTask):
             'OCR Model': {
                 'type': 'string',
                 'enum': ['gothic_salzinnes_2021', 'ms73_latinhist_2021',"gothic_salzinnes_2023","salzinnes_stgall"],
-                'default': 'gothic_salzinnes_2021',
+                'default': 'salzinnes_stgall',
                 'description': ('The OCR model used to obtain a \'messy\' transcript, which will '
                                 'then be aligned to the given transcript.')
             }


### PR DESCRIPTION
Resolves: (#ID-of-the-issue)
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

Changes the default text alignment model to be the newest