### PR TITLE
Multi-column MEI encoding/unsplitting

### DIFF
--- a/rodan-main/code/rodan/jobs/MEI_encoding/MEI_encoding.py
+++ b/rodan-main/code/rodan/jobs/MEI_encoding/MEI_encoding.py
@@ -50,6 +50,12 @@ class MEI_encoding(RodanTask):
         'minimum': 1,
         'maximum': 1,
         'is_list': False
+    }, {
+        'name': 'Column Splitting Data',
+        'resource_types': ['application/json'],
+        'minimum': 0,
+        'maximum': 1,
+        'is_list': False
     }
     ]
 
@@ -69,6 +75,13 @@ class MEI_encoding(RodanTask):
         with open(jsomr_path, 'r') as file:
             jsomr = json.loads(file.read())
 
+        if 'Column Splitting Data' in inputs:
+            split_ranges_path = inputs['Column Splitting Data'][0]['resource_path']
+            with open(split_ranges_path, 'r') as file:
+                split_ranges = json.loads(file.read())
+        else:
+            split_ranges = None
+
         try:
             alignment_path = inputs['Text Alignment JSON'][0]['resource_path']
         except KeyError:
@@ -82,7 +95,7 @@ class MEI_encoding(RodanTask):
         self.logger.info('fetching classifier...')
         classifier_table, width_container = pct.fetch_table_from_csv(inputs['MEI Mapping CSV'][0]['resource_path'])
         width_mult = settings[u'Neume Component Spacing']
-        mei_string = bm.process(jsomr, syls, classifier_table, width_mult, width_container)
+        mei_string = bm.process(jsomr, syls, classifier_table, width_mult, width_container, split_ranges)
 
         self.logger.info('writing to file...')
         outfile_path = outputs['MEI'][0]['resource_path']

--- a/rodan-main/code/rodan/jobs/MEI_encoding/build_mei_file.py
+++ b/rodan-main/code/rodan/jobs/MEI_encoding/build_mei_file.py
@@ -148,7 +148,7 @@ def neume_to_lyric_alignment(glyphs: List[dict], syl_boxes: List[dict], median_l
     return pairs
 
 
-def generate_base_document(column_split_info: dict):
+def generate_base_document(column_split_info: Optional[dict]):
     '''
     Generates a generic template for an MEI document for neume notation.
 
@@ -487,7 +487,7 @@ def staff_to_columns_dict(staves: List[dict], height: int, num_columns):
         out[i] = column
     return out
 
-def build_mei(pairs: List[Tuple[List[dict], dict]], classifier: dict, width_container: dict, staves: List[dict], page: dict, column_split_info: dict):
+def build_mei(pairs: List[Tuple[List[dict], dict]], classifier: dict, width_container: dict, staves: List[dict], page: dict, column_split_info: Optional[dict]):
     '''
     Encodes the final MEI document using:
         @pairs: Pairs from the neume_to_lyric_alignment.
@@ -583,7 +583,7 @@ def build_mei(pairs: List[Tuple[List[dict], dict]], classifier: dict, width_cont
         syl_dict = {"opening_syl": cur_syllable, "latest": syl, "added": False, "neume_added": False}
         # iterate over glyphs on the page that fall within the bounds of this syllable
         for i, glyph in enumerate(gs):
-            # if there are multiple columns, shift glyph box
+            # if there are multiple columns, shift the glyph box back to was in the original input image
             if is_multi_column:
                 curr_column = staff_to_column[int(glyph['staff'])-1]
                 glyph["bounding_box"] = translate_bbox(glyph["bounding_box"], column_split_info["split_ranges"], height, curr_column)
@@ -639,8 +639,7 @@ def build_mei(pairs: List[Tuple[List[dict], dict]], classifier: dict, width_cont
             cur_staff = int(glyph['staff'])
 
             # if multi column and next system is new column, add new cb
-            if is_multi_column:
-                if staff_to_column[cur_staff] > prev_column:
+            if is_multi_column and staff_to_column[cur_staff] > prev_column:
                     # add cb to layer
                     zoneId = generate_zone(surface, previous_cb["bb"])
                     previous_cb["cb"].set("facs", "#" + zoneId)


### PR DESCRIPTION
Resolves: (#ID-of-the-issue)
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

Implements support for multi-column folios in mei encoding as well as reversing the splitting done by the new column splitting job. Currently multi-column folios are not supported in Neon.

All lines of code related to multiple columns are wrapped in an "if multi_column" block, so for regular folios this has no affect.