### PR TITLE
Fix typo in sending workflow failure emails

### DIFF
--- a/rodan-main/code/rodan/jobs/base.py
+++ b/rodan-main/code/rodan/jobs/base.py
@@ -1012,7 +1012,7 @@ class RodanTask(Task,metaclass=RodanTaskType):
             if (
                 user.email
                 and rodan_settings.EMAIL_USE
-                and user.user_preference.sned_email
+                and user.user_preference.send_email
             ):
                 to = [user.email]
                 email_template = "rodan/email/workflow_run_failed.html"


### PR DESCRIPTION
Resolves: (#1029)
- [ ] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

(Describe the changes you've made and the purpose of this PR)
- Fix typo in send workflow failure email function