### PR TITLE
Center new workflow job groups

### DIFF
--- a/rodan-client/code/src/js/Controllers/ControllerWorkflowJobGroup.js
+++ b/rodan-client/code/src/js/Controllers/ControllerWorkflowJobGroup.js
@@ -3,6 +3,7 @@ import RODAN_EVENTS from 'js/Shared/RODAN_EVENTS';
 import Radio from 'backbone.radio';
 import WorkflowJobGroup from 'js/Models/WorkflowJobGroup';
 import WorkflowJobGroupCollection from 'js/Collections/WorkflowJobGroupCollection';
+import wfbgui from 'js/WorkflowBuilderGUI';
 
 /**
  * Controller for WorkflowJobGroups.
@@ -56,7 +57,9 @@ export default class ControllerWorkflowJobGroup extends BaseController
         {
             urls.push(workflowJobs[index].get('url'));
         }
-        var workflowJobGroup = new WorkflowJobGroup({workflow_jobs: urls, workflow: workflow});
+        const boundingBox = wfbgui._getBoundingBox(workflowJobs);
+        const appearance = wfbgui._getBoundingBoxCenter(boundingBox);
+        var workflowJobGroup = new WorkflowJobGroup({ appearance, workflow_jobs: urls, workflow: workflow });
         workflowJobGroup.save({}, {success: (model) => this._handleWorkflowJobGroupCreationSuccess(model)});
     }
 

--- a/rodan-client/code/src/js/WorkflowBuilderGUI.js
+++ b/rodan-client/code/src/js/WorkflowBuilderGUI.js
@@ -515,7 +515,7 @@ class WorkflowBuilderGUI
     {
         const boundingBox = this._getWorkflowBoundingBox();
         if (boundingBox) {
-            const workflowCenter = this._getWorkflowCenter(boundingBox);
+            const workflowCenter = this._getBoundingBoxCenter(boundingBox);
             paper.view.center = workflowCenter;
             const width = boundingBox.bottomRight.x - boundingBox.topLeft.x + 2 * Rodan.Configuration.PLUGINS['rodan-client-wfbgui'].WORKFLOW_PADDING;
             const height = boundingBox.bottomRight.y - boundingBox.topLeft.y + 2 * Rodan.Configuration.PLUGINS['rodan-client-wfbgui'].WORKFLOW_PADDING;
@@ -540,33 +540,47 @@ class WorkflowBuilderGUI
     }
 
     /**
+     * Calculates the bounding box given a list of workflow jobs.
+     * @param {WorkflowJob[]} workflow_jobs - The workflow jobs to calculate the bounding box for.
+     * @returns the bounding box of the workflow jobs or null if no workflow_jobs are provided.
+     */
+    _getBoundingBox(workflow_jobs)
+    {
+        if (!workflow_jobs) return null;
+        let minX, maxX, minY, maxY;
+        workflow_jobs.forEach(job => {
+            const { x, y } = job.get('appearance');
+            minX = minX === undefined || x < minX ? x : minX;
+            maxX = maxX === undefined || x > maxX ? x : maxX;
+            minY = minY === undefined || y < minY ? y : minY;
+            maxY = maxY === undefined || y > maxY ? y : maxY;
+        });
+        const topLeft = { x: minX, y: minY };
+        const bottomRight = { x: maxX, y: maxY };
+        return { topLeft, bottomRight };
+    }
+    
+    /**
      * Calculate the bounding box of the workflow in paper.js project coordinates.
      * @returns {{topLeft: {x: number, y: number}, bottomRight: {x: number, y: number}} | null} The bounds of the workflow in paper.js project coordinates or null if there are no jobs.
      */
     _getWorkflowBoundingBox()
     {
-        let minX, maxX, minY, maxY;
         if (this._workflow && this._workflow.get('workflow_jobs').length > 0) {
-            this._workflow.get('workflow_jobs').forEach(job => {
-                const { x, y } = job.get('appearance');
-                minX = minX === undefined || x < minX ? x : minX;
-                maxX = maxX === undefined || x > maxX ? x : maxX;
-                minY = minY === undefined || y < minY ? y : minY;
-                maxY = maxY === undefined || y > maxY ? y : maxY;
-            });
-            const topLeft = BaseItem.appearanceToProject({ x: minX, y: minY });
-            const bottomRight = BaseItem.appearanceToProject({ x: maxX, y: maxY });
+            const boundingBox = this._getBoundingBox(this._workflow.get('workflow_jobs'));
+            const topLeft = BaseItem.appearanceToProject(boundingBox.topLeft);
+            const bottomRight = BaseItem.appearanceToProject(boundingBox.bottomRight);
             return { topLeft, bottomRight };
         }
         return null;
     }
 
     /**
-     * Calculates the paper.js project coordinates of the center of the workflow.
-     * @param {{topLeft: {x: number, y: number}, bottomRight: {x: number, y: number}} | null} boundingBox The bounding box of the workflow in paper.js project coordinates.
-     * @return {{x: number, y: number} | null} The center of the workflow in paper.js project coordinates or null if no bounding box is provided.
+     * Calculates the center of a bounding box.
+     * @param {{topLeft: {x: number, y: number}, bottomRight: {x: number, y: number}} | null} boundingBox The bounding box.
+     * @return {{x: number, y: number} | null} The center of the bounding box or null if no bounding box is provided.
     */
-    _getWorkflowCenter(boundingBox)
+    _getBoundingBoxCenter(boundingBox)
     {
         return boundingBox ? { x: (boundingBox.topLeft.x + boundingBox.bottomRight.x) / 2, y: (boundingBox.topLeft.y + boundingBox.bottomRight.y) / 2 } : null;
     }
@@ -578,9 +592,7 @@ class WorkflowBuilderGUI
      */
     _handleGetNewJobPosition()
     {
-        const x = this._rightClickPosition === null ? paper.view.center.x : this._rightClickPosition.x;
-        const y = this._rightClickPosition === null ? paper.view.center.y : this._rightClickPosition.y;
-        const position = { x, y};
+        const position = this._rightClickPosition == null ? paper.view.center : this._rightClickPosition;
         return BaseItem.projectToAppearance(position);
     }
 


### PR DESCRIPTION
Resolves: (#1011)
- [ ] I passed the docker hub test, and images can be built successfully.
- [ ] I passed the GitHub CI test, so rodan functionalities and jobs work.

(Describe the changes you've made and the purpose of this PR)
- Modify methods to calculate bounding boxes in WorkflowBuilderGUI to be reused in ControllerWorkflowJobGroup 
- Use the centre of selected workflow jobs instead of the canvas when creating new job groups 