### PR TITLE
Fix modal error messages

### DIFF
--- a/rodan-client/code/src/js/Controllers/ControllerModal.js
+++ b/rodan-client/code/src/js/Controllers/ControllerModal.js
@@ -119,7 +119,7 @@ export default class ControllerModal extends BaseController
         }
         else
         {
-            Radio.channel('rodan').request(RODAN_EVENTS.REQUEST__MODAL_SHOW, {title: 'ERROR', content: options.content});
+            Radio.channel('rodan').request(RODAN_EVENTS.REQUEST__MODAL_SHOW, {title: options.title || 'Error', content: options.content});
         }
         $('.modal-footer').addClass('modal-footer-error');
     }

--- a/rodan-client/code/src/js/Managers/ErrorManager.js
+++ b/rodan-client/code/src/js/Managers/ErrorManager.js
@@ -53,31 +53,7 @@ export default class ErrorHandler
             }
             else
             {
-                var response = options.response;
-                var responseTextObject = JSON.parse(response.responseText);
-                var message = 'An unknown error occured.';
-
-                // Look for message in options first.
-                if (options.hasOwnProperty('message'))
-                {
-                    message = options.message;
-                }
-
-                // Go through the response text.
-                var first =  true;
-                for(var property in responseTextObject)
-                {
-                    if (responseTextObject.hasOwnProperty(property))
-                    {
-                        message += '\n';
-                        if (first)
-                        {
-                            message += '\n';
-                            first = false;
-                        }
-                        message += responseTextObject[property];
-                    }
-                }
+                var message = options.message || 'An unknown error occured.';
                 this._showError(message, null);
             }
         }
@@ -92,7 +68,9 @@ export default class ErrorHandler
      */
     _showError(text, error)
     {
-        console.error(error);
-        Radio.channel('rodan').request(RODAN_EVENTS.REQUEST__MODAL_ERROR, {content: text, title: 'Error'});
+        if (error) {
+            console.error(error);
+        }
+        Radio.channel('rodan').request(RODAN_EVENTS.REQUEST__MODAL_ERROR, {content: text});
     }
 }


### PR DESCRIPTION
Resolves: (#1058)
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

(Describe the changes you've made and the purpose of this PR)
- Change modal error messages to either display a specified message or simply "An unknown error occured.", rather than dumping the contents of the JSON response