### PR TITLE
Remove duplicate `SERVER_HOST` environment variable

### DIFF
--- a/arm-compose.yml
+++ b/arm-compose.yml
@@ -22,6 +22,7 @@ services:
       start_period: "2m"
     command: bash -c "tail -f /dev/null"
     environment:
+      SERVER_HOST: localhost
       CELERY_JOB_QUEUE: None
     depends_on:
       - postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       start_period: "2m"
     command: bash -c "tail -f /dev/null"
     environment:
+      SERVER_HOST: localhost
       CELERY_JOB_QUEUE: None
     depends_on:
       - postgres

--- a/scripts/local.env
+++ b/scripts/local.env
@@ -14,7 +14,6 @@ DJANGO_ADMIN_URL=^api/admin/
 IIPSRV_URL=http://localhost/fcgi-bin/iipsrv.fcgi/
 DJANGO_ACCESS_LOG=/code/Rodan/rodan.log
 DJANGO_DEBUG_LOG=/code/Rodan/database.log
-SERVER_HOST=localhost
 
 ###############################################################################
 # SMTP Configuration

--- a/scripts/production.sample
+++ b/scripts/production.sample
@@ -14,7 +14,6 @@ DJANGO_ADMIN_URL=^api/random_secret_admin/
 IIPSRV_URL=https://rodan2.simssa.ca/fcgi-bin/iipsrv.fcgi/
 DJANGO_ACCESS_LOG=/code/Rodan/rodan.log
 DJANGO_DEBUG_LOG=/code/Rodan/database.log
-SERVER_HOST=rodan2.simssa.ca
 
 ###############################################################################
 # SMTP Configuration

--- a/scripts/staging.sample
+++ b/scripts/staging.sample
@@ -14,7 +14,6 @@ DJANGO_ADMIN_URL=^api/random_secret_admin/
 IIPSRV_URL=http://rodan-staging.simssa.ca/fcgi-bin/iipsrv.fcgi/
 DJANGO_ACCESS_LOG=/code/Rodan/rodan.log
 DJANGO_DEBUG_LOG=/code/Rodan/database.log
-SERVER_HOST=rodan-staging.simssa.ca
 
 ###############################################################################
 # SMTP Configuration


### PR DESCRIPTION
Resolves: (#1057)
- [ ] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

(Describe the changes you've made and the purpose of this PR)
- Remove `SERVER_HOST` environment variable in `staging.sample` and `production.sample` which is already provided in `staging.yml` and `production.yml`
- Move `SERVER_HOST` environment variable from`local.env` to `docker-compose.yml` and `arm-compose.yml` to be consistent with staging and production