### PR TITLE
Fix #1088, Fix make pull

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ push:
 
 pull:
 	@echo "[-] Pulling docker images from Docker Hub..."
-	@docker compose pull
+	@DOCKER_TAG=$(DOCKER_TAG) docker compose pull
 	@echo "[+] Done."
 
 $(JOBS_PATH)/neon_wrapper/Neon/package.json:


### PR DESCRIPTION
- Add default tags when doing make pull

Resolves: #1088
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

(Describe the changes you've made and the purpose of this PR)