### PR TITLE
Fix #1087, Fix nginx's start script

### DIFF
--- a/nginx/scripts/start
+++ b/nginx/scripts/start
@@ -7,10 +7,10 @@ set -o xtrace # Print commands and their arguments as they are executed.
 #sed -i "s/SERVER_HOST/${SERVER_HOST}/g" /etc/nginx/conf.d/ssl.conf
 
 # Wait for everything to be up.
-/run/wait-for-app iipsrv:9003
+# /run/wait-for-app iipsrv:9003
 /run/wait-for-app redis:6379
-/run/wait-for-app rodan-main:8000
-/run/wait-for-app rodan-client
+/run/wait-for-app rodan-main:8000 --timeout=900
+/run/wait-for-app rodan-client:80
 
 nginx
 #tail -f /var/log/nginx/access.log & tail -f /var/log/nginx/error.log


### PR DESCRIPTION
Resolves: #1087 
- [ ] I passed the docker hub test, and images can be built successfully.
- [ ] I passed the GitHub CI test, so rodan functionalities and jobs work.
* Can't talk to iipsrv:9003 so comment out that line
* Need to specify the port when trying to connect to rodan-client
* Wait for 900 secs when establishing tcp connection with rodan-main