### PR TITLE
Fix #1093, Fix iipsrv start script

### DIFF
--- a/iipsrv/Dockerfile
+++ b/iipsrv/Dockerfile
@@ -34,4 +34,4 @@ ENV PORT 9003
 
 EXPOSE ${PORT}
 
-ENTRYPOINT ["/fcgi-bin/iipsrv.fcgi", "--bind", "0.0.0.0:${PORT}"]
+ENTRYPOINT ./src/iipsrv.fcgi --bind 0.0.0.0:${PORT}

--- a/nginx/scripts/start
+++ b/nginx/scripts/start
@@ -7,7 +7,7 @@ set -o xtrace # Print commands and their arguments as they are executed.
 #sed -i "s/SERVER_HOST/${SERVER_HOST}/g" /etc/nginx/conf.d/ssl.conf
 
 # Wait for everything to be up.
-# /run/wait-for-app iipsrv:9003
+/run/wait-for-app iipsrv:9003
 /run/wait-for-app redis:6379
 /run/wait-for-app rodan-main:8000 --timeout=900
 /run/wait-for-app rodan-client:80


### PR DESCRIPTION
Resolves: #1093 
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

(Describe the changes you've made and the purpose of this PR)