### PR TITLE
Fix #1093, Fix iipsrv port

### DIFF
--- a/iipsrv/Dockerfile
+++ b/iipsrv/Dockerfile
@@ -34,4 +34,4 @@ ENV PORT 9003
 
 EXPOSE ${PORT}
 
-ENTRYPOINT ./src/iipsrv.fcgi --bind 0.0.0.0:${PORT}
+ENTRYPOINT /fcgi-bin/iipsrv.fcgi --bind 0.0.0.0:${PORT}


### PR DESCRIPTION
Resolves: (#ID-of-the-issue)
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

(Describe the changes you've made and the purpose of this PR)