### PR TITLE
Fix text overflow in pop-up window

### DIFF
--- a/rodan-client/code/styles/default.css
+++ b/rodan-client/code/styles/default.css
@@ -946,6 +946,7 @@ div#main_workflowbuilder
     background-color: white;
     backdrop-filter: blur(20px);
     min-width: 500px;
+    max-width: 100%;
     /* min-height: 300px; */
 }
 .modal-header {


### PR DESCRIPTION
Fixes #1102 by setting the maximum width of the model window.

Resolves: #1102
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

 Set the maximum width of the model dialog.
