### PR TITLE
fix: fix alpine version to 3.18.5 in iipsrv

### DIFF
--- a/iipsrv/Dockerfile
+++ b/iipsrv/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine AS builder
+FROM alpine:3.18.5 AS builder
 
 RUN apk add --no-cache \
   autoconf \
@@ -15,7 +15,7 @@ RUN ./autogen.sh
 RUN ./configure --enable-openjpeg
 RUN make
 
-FROM alpine
+FROM alpine:3.18.5
 
 RUN apk add --no-cache \
   libgcc \


### PR DESCRIPTION

- alpine:3.19.0 does not work because of a missing library (libwebpmux.so)

- [ ] I passed the docker hub test, and images can be built successfully.
- [ ] I passed the GitHub CI test, so rodan functionalities and jobs work.
