### PR TITLE
Solve name_set type error in interactive classifier

### DIFF
--- a/rodan-main/code/rodan/jobs/interactive_classifier/interactive_classifier.py
+++ b/rodan-main/code/rodan/jobs/interactive_classifier/interactive_classifier.py
@@ -289,8 +289,8 @@ def serialize_class_names_to_json(settings):
     for image in database:
         cln=image['class_name']
         if type(cln)==bytes:
-             cln=cln.decode()
-        name_set.add(image['class_name'])
+            cln=cln.decode()
+        name_set.add(cln)
 
     for name in imported_class_names:
         if type(name)==bytes:


### PR DESCRIPTION
Resolves: #1179
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

The class name, when comes from training xml, is of type bytes. It was decoded but it was the original one that was added to the `name_set`. Updated to adding the decoded name.