### PR TITLE
Fix gpu dockerfile

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -49,8 +49,3 @@ services:
       dockerfile: Dockerfile
     image: "ddmal/rodan-client:nightly"
 
-  iipsrv:
-    build:
-      context: ./iipsrv
-      dockerfile: Dockerfile
-    image: "ddmal/iipsrv:nightly"

--- a/gpu-celery/Dockerfile
+++ b/gpu-celery/Dockerfile
@@ -94,7 +94,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* \
-  && wget https://bootstrap.pypa.io/get-pip.py \
+  && wget https://bootstrap.pypa.io/pip/3.7/get-pip.py \
   && ${PYTHON} get-pip.py \
   && ln -sf /usr/bin/${PYTHON} /usr/local/bin/python3 \
   && ln -sf /usr/local/bin/pip /usr/local/bin/pip3 \


### PR DESCRIPTION
Resolves: (#1185)
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

Fixed Dockerfile for gpu-celery container where pip install was no longer supported for python < 3.8 with the old link.
Removed duplicate iipsrv block in build.yml.

ci/dockercloud-stage should work again.