### PR TITLE
Fix paco classifying and update paco code repo tag to v2.0.4

### DIFF
--- a/scripts/install_gpu_rodan_jobs
+++ b/scripts/install_gpu_rodan_jobs
@@ -37,7 +37,7 @@ which pip3 && $PIP install --no-cache-dir .
 
 # Install Paco classifier
 cd /
-git clone -b v2.0.3 --depth 1 https://github.com/DDMAL/Paco_classifier.git
+git clone -b v2.0.4 --depth 1 https://github.com/DDMAL/Paco_classifier.git
 mv Paco_classifier .Paco_classifier
 cd .Paco_classifier
 which pip3 && $PIP install --no-cache-dir .


### PR DESCRIPTION
Paco tag v2.0.4 has two newer commits to main, which fixed the training algorithm, and the same requirement.txt as the previous v2.0.3.

Resolves: (#1209)
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

Our Rodan now should point to the latest Paco codes. All changes are captured in the tag v2.0.4 with the currently used, fixed dependencies, and the fix for the inference step in the classifying job. (Please refer to the issue for more details.)
Kyrie and I have tested the new docker images on our local machine and grid lines are no longer there with the same model.