### PR TITLE
Fix outputname

### DIFF
--- a/rodan-main/code/rodan/jobs/resource_distributor.py
+++ b/rodan-main/code/rodan/jobs/resource_distributor.py
@@ -175,18 +175,18 @@ class ResourceDistributor(RodanTask):
     def test_my_task(self, testcase):
         import PIL.Image
         import numpy as np
-        resource_types_list = list(map(lambda rt: str(rt.mimetype), ResourceType.objects.all()))
-        from model_mommy import mommy
         from rodan.models import Resource, ResourceType
+        resource_types_list = list(map(lambda rt: str(rt.mimetype), ResourceType.objects.all()))
+        from model_mommy import mommy        
 
         # Create a Resource instance using mommy
-        resource_type = mommy.make(ResourceType, mimetype="image/rgb+png")
-        rc = mommy.make(Resource, resource_type=resource_type)
+        resource_type, created = ResourceType.objects.get_or_create(mimetype="image/rgb+png")
+        rc = mommy.make(Resource, resource_type=resource_type, name="test_filename")
 
         inputs = {
                     "Resource input": [
                         {
-                            "resource_path": rc.resource_path,
+                            "resource_path": testcase.new_available_path(),
                             "resource_type": rc.resource_type.mimetype,
                             "resource": rc
                         }
@@ -223,5 +223,6 @@ class ResourceDistributor(RodanTask):
         # and the data should be identical
         np.testing.assert_equal(array_gt, array_result)
 
+        # Test name change
         new_name = f"{settings['User custom prefix']}{original_image}{settings['User custom suffix']}"
         testcase.assertEqual(inputs['Resource input'][0]['resource'].name, new_name)

--- a/rodan-main/code/rodan/jobs/resource_distributor.py
+++ b/rodan-main/code/rodan/jobs/resource_distributor.py
@@ -2,7 +2,24 @@ __version__ = "1.0.0"
 import shutil
 
 from rodan.jobs.base import RodanTask
-from rodan.models import ResourceType
+from rodan.models import ResourceType, Input, Output
+from django.conf import settings as rodan_settings
+
+import logging
+
+logger = logging.getLogger("rodan")
+
+def log_structure(data, level=0):
+    if isinstance(data, dict):
+        for key, value in data.items():
+            logger.info("%sKey: %s", "    " * level, key)
+            log_structure(value, level + 1)
+    elif isinstance(data, list):
+        for idx, item in enumerate(data):
+            logger.info("%sIndex %d:", "    " * level, idx)
+            log_structure(item, level + 1)
+    else:
+        logger.info("%sValue: %s", "    " * level, data)
 
 
 class ResourceDistributor(RodanTask):
@@ -18,6 +35,16 @@ class ResourceDistributor(RodanTask):
                 'type': 'string',
                 'default': 'application/octet-stream',
                 'description': 'Specifies the eligible resource types for input'
+            },
+            'User custom prefix': {
+                'type': 'string',
+                'default': 'custom prefix - ',
+                'description': 'User specified prefix (please also include space, hyphen, etc.)'
+            },
+            'User custom suffix': {
+                'type': 'string',
+                'default': '- custom suffix',
+                'description': 'User specified suffix (please also include space, hyphen, etc.)'
             }
         }
     }
@@ -44,8 +71,66 @@ class ResourceDistributor(RodanTask):
         },
     )
 
+
+    def _inputs(self, runjob, with_urls=False):
+        """
+        Return a dictionary of list of input file path and input resource type.
+        If with_urls=True, it also includes the resource url and thumbnail urls.
+        """
+
+        self.runjob = runjob
+
+        def _extract_resource(resource, resource_type_mimetype=None):
+            r = {
+                # convert 'unicode' object to 'str' object for consistency
+                "resource_path": str(resource.resource_file.path),
+                "resource_type": str(
+                    resource_type_mimetype or resource.resource_type.mimetype
+                ),
+                "resource": resource,
+            }
+            if with_urls:
+                r["resource_url"] = str(resource.resource_url)
+                r["diva_object_data"] = str(resource.diva_json_url)
+                r["diva_iip_server"] = getattr(rodan_settings, "IIPSRV_URL")
+                r["diva_image_dir"] = str(resource.diva_image_dir)
+            return r
+
+        input_objs = (
+            Input.objects.filter(run_job=runjob)
+            .select_related("resource", "resource__resource_type", "resource_list")
+            .prefetch_related("resource_list__resources")
+        )
+
+        inputs = {}
+        for input in input_objs:
+            ipt_name = str(input.input_port_type_name)
+            if ipt_name not in inputs:
+                inputs[ipt_name] = []
+            if input.resource is not None:  # If resource
+                inputs[ipt_name].append(_extract_resource(input.resource))
+            elif input.resource_list is not None:  # If resource_list
+                inputs[ipt_name].append(
+                    map(
+                        lambda x: _extract_resource(
+                            x, input.resource_list.get_resource_type().mimetype
+                        ),
+                        input.resource_list.resources.all(),
+                    )
+                )
+            else:
+                raise RuntimeError(
+                    (
+                        "Cannot find any resource or resource list on Input" " {0}"
+                    ).format(input.uuid)
+                )
+        return inputs
+    
     def run_my_task(self, inputs, settings, outputs):
+        # log_structure(inputs)
         input_type = inputs['Resource input'][0]['resource_type']
+        input_resource = inputs['Resource input'][0]['resource']
+        input_name = input_resource.name
         valid_input_type_num = settings['Resource type']
         valid_input_type = self.settings['properties']['Resource type']['enum'][valid_input_type_num]  # noqa
         if input_type != valid_input_type:
@@ -57,8 +142,29 @@ class ResourceDistributor(RodanTask):
                 ).format(input_type, valid_input_type)
             )
             return False
+        prefix = settings["User custom prefix"]
+        if not isinstance(prefix, str):
+            self.my_error_information(
+                None,
+                ("User custom prefix can only be strings")
+            )
+            return False
+        suffix = settings["User custom suffix"]
+        if not isinstance(suffix, str):
+            self.my_error_information(
+                None,
+                ("User custom suffix can only be strings")
+            )
+            return False
+        new_name = prefix + input_name + suffix
+        assert isinstance(new_name,str)
+        
+        input_resource.rename(new_name)
+        input_resource.save(update_fields=["resource_file"])
+
         outfile_path = outputs['Resource output'][0]['resource_path']
         infile_path = inputs['Resource input'][0]['resource_path']
+
         shutil.copyfile(infile_path, outfile_path)
         return True
 

--- a/rodan-main/code/rodan/models/resource.py
+++ b/rodan-main/code/rodan/models/resource.py
@@ -142,6 +142,10 @@ class Resource(models.Model):
 
     labels = models.ManyToManyField(ResourceLabel, blank=True)
 
+    def rename(self, newname):
+        self.name = newname
+        self.save()
+
     def save(self, *args, **kwargs):
         super(Resource, self).save(*args, **kwargs)
         if not os.path.exists(self.resource_path):


### PR DESCRIPTION
Resolves: (#1190)
- [ ] I passed the docker hub test, and images can be built successfully.
- [ ] I passed the GitHub CI test, so rodan functionalities and jobs work.

Enable user specified renaming of an output within the job Resource Distributor:
- add `custom prefix` and `custom suffix`
- update unit test

* Users should consider the file formatting themselves. For example, "custom prefix - " will lead to "custom prefix - old name" while "custom prefix" will become"custom prefixold name".
