### PR TITLE
Release v3.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ REPLACE := perl -i -pe
 RODAN_PATH := ./rodan-main/code/rodan
 JOBS_PATH := $(RODAN_PATH)/jobs
 
-PROD_TAG := v3.0.0
+PROD_TAG := v3.1.0
 
 DOCKER_TAG := nightly
 

--- a/production.yml
+++ b/production.yml
@@ -3,7 +3,7 @@ version: "3.4"
 services:
 
   nginx:
-    image: "ddmal/nginx:v3.0.0"
+    image: "ddmal/nginx:v3.1.0"
     deploy:
       replicas: 1
       resources:
@@ -37,7 +37,7 @@ services:
       - "resources:/rodan/data"
 
   rodan-main:
-    image: "ddmal/rodan-main:v3.0.0"
+    image: "ddmal/rodan-main:v3.1.0"
     deploy:
       replicas: 1
       resources:
@@ -78,7 +78,7 @@ services:
       - "resources:/rodan/data"
 
   celery:
-    image: "ddmal/rodan-main:v3.0.0"
+    image: "ddmal/rodan-main:v3.1.0"
     deploy:
       replicas: 1
       resources:
@@ -109,7 +109,7 @@ services:
       - "resources:/rodan/data"
 
   py3-celery:
-    image: "ddmal/rodan-python3-celery:v3.0.0"
+    image: "ddmal/rodan-python3-celery:v3.1.0"
     deploy:
       replicas: 1
       resources:
@@ -139,7 +139,7 @@ services:
       - "resources:/rodan/data"
 
   gpu-celery:
-    image: "ddmal/rodan-gpu-celery:v3.0.0"
+    image: "ddmal/rodan-gpu-celery:v3.1.0"
     deploy:
       replicas: 1
       resources:
@@ -195,7 +195,7 @@ services:
       TZ: America/Toronto
 
   postgres:
-    image: "ddmal/postgres-plpython:v3.0.0"
+    image: "ddmal/postgres-plpython:v3.1.0"
     deploy:
       replicas: 1
       endpoint_mode: dnsrr

--- a/rodan-main/code/rodan/__init__.py
+++ b/rodan-main/code/rodan/__init__.py
@@ -17,7 +17,7 @@ from .celery import app as celery_app
 # Get version: import rodan; rodan.__version__
 # Version numbers also appear in the API.
 __title__ = "Rodan"
-__version__ = "v3.0.0"
+__version__ = "v3.1.0"
 __copyright__ = "Copyright 2011-2022 Distributed Digital Music Archives & Libraries Lab"
 # If changing this line, also change rodan-main/Dockerfile
 __build_hash__ = "local"


### PR DESCRIPTION
- Fix setting: alpine version in iipsrv
- Fix setting: pip install source url in gpu dockerfile
- Fix setting: tag update for fixed PACO code

- Fix UI: resource assignment modal window layout
- Fix UI: modal window grid
- Fix UI: scroll
- Fix UI: modal window styles
- Fix UI: clear view on workflow delete

- Fix job: StaffFinding adaptive blackness threshold
- Fix job: IC type error
- Fix job: batch downloading
- Fix job: heuristic pitch finding default octave
- Fix job: Miyao staff finding test file

- New feature: extract c clef job
- New feature: rename in resource distributor

Resolves: (#ID-of-the-issue)
- [ ] I passed the docker hub test, and images can be built successfully.
- [ ] I passed the GitHub CI test, so rodan functionalities and jobs work.

Merge release v3.1.0 into develop with new changes since v3.0.0.