### PR TITLE
Fix 1173 pixelwrapper

### DIFF
--- a/ci-jobs/Dockerfile
+++ b/ci-jobs/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add \
   yarn
 
 # Build Pixel
-RUN git clone --recurse-submodules -b v2.0.1 https://github.com/DDMAL/pixel_wrapper.git
+RUN git clone --recurse-submodules -b v2.0.2 https://github.com/DDMAL/pixel_wrapper.git
 WORKDIR /pixel_wrapper/
 RUN python3 activate_wrapper.py
 RUN npm install

--- a/python3-celery/Dockerfile
+++ b/python3-celery/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add \
   yarn
 
 # Build Pixel
-RUN git clone --recurse-submodules -b v2.0.1 https://github.com/DDMAL/pixel_wrapper.git
+RUN git clone --recurse-submodules -b v2.0.2 https://github.com/DDMAL/pixel_wrapper.git
 WORKDIR /pixel_wrapper/
 RUN python3 activate_wrapper.py
 RUN npm install


### PR DESCRIPTION
Resolves: (#1173)
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

Point to the latest Pixel_wrapper code (tag v2.0.2) in both PY3-celery Dockerfile and ci-jobs Dockerfile.