### PR TITLE
update github runner version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - develop
 jobs:
   rodan-CI-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
         image: ddmal/ci-jobs:django-v2.0.13
         env: 

--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release-checklist:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3


### PR DESCRIPTION
Resolves: (#1250)
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

Update Ubuntu version from 20.04 to 22.04 for Github action runner for CI workflow.