### PR TITLE
Release v3.2.0 to develop

### DIFF
--- a/production.sample
+++ b/production.sample
@@ -1,0 +1,294 @@
+version: "3.4"
+
+services:
+
+  nginx:
+    image: "ddmal/nginx:v3.2.0"
+    deploy:
+      replicas: 1
+      resources:
+        reservations:
+          cpus: "0.25"
+          memory: 0.5G
+        limits:
+          cpus: "0.25"
+          memory: 0.5G
+      restart_policy:
+        condition: any
+        delay: 5s
+        window: 30s
+      placement:
+        constraints:
+          - node.role == manager
+    healthcheck:
+      test: ["CMD", "/usr/sbin/service", "nginx", "status"]
+      interval: "30s"
+      timeout: "10s"
+      retries: 10
+      start_period: "5m"
+    command: /run/start
+    environment:
+      TZ: America/Toronto
+      SERVER_HOST: rodan2.simssa.ca
+      TLS: 1
+    ports:
+      - "80:80"
+      - "443:443"
+      - "5671:5671"
+      - "9002:9002"
+    volumes:
+      - "resources_nfs:/rodan/data"
+
+  rodan-main:
+    image: "ddmal/rodan-main:v3.2.0"
+    deploy:
+      replicas: 1
+      resources:
+        reservations:
+          cpus: "1.5"
+          memory: 6G
+        limits:
+          cpus: "1.5"
+          memory: 6G
+      restart_policy:
+        condition: any
+        delay: 5s
+        window: 30s
+      placement:
+        constraints:
+          - node.role == manager
+    healthcheck:
+      test: ["CMD-SHELL", "/usr/bin/curl -H 'User-Agent: docker-healthcheck' http://localhost:8000/api/?format=json || exit 1"]
+      interval: "30s"
+      timeout: "30s"
+      retries: 5
+      start_period: "15m"
+    command: /run/start
+    environment:
+      TZ: America/Toronto
+      SERVER_HOST: rodan2.simssa.ca
+      CELERY_JOB_QUEUE: None
+    env_file:
+      - ./scripts/production.env
+    volumes:
+      - "resources_nfs:/rodan/data"
+
+  rodan-client:
+    image: "ddmal/rodan-client:nightly"
+    deploy:
+      placement:
+        constraints:
+          - node.role == worker
+    volumes:
+      - "./rodan-client/config/configuration.json:/client/configuration.json"
+
+  iipsrv:
+    image: "ddmal/iipsrv:nightly"
+    volumes:
+      - "resources_nfs:/rodan/data"
+
+  celery:
+    image: "ddmal/rodan-main:v3.2.0"
+    deploy:
+      replicas: 1
+      resources:
+        reservations:
+          cpus: "2"
+          memory: 6G
+        limits:
+          cpus: "2"
+          memory: 6G
+      restart_policy:
+        condition: any
+        delay: 5s
+        window: 30s
+      placement:
+        constraints:
+          - node.role == manager
+    healthcheck:
+      test: ["CMD", "celery", "inspect", "ping", "-A", "rodan", "--workdir", "/code/Rodan", "-d", "celery@celery", "-t", "30"]
+      interval: "30s"
+      timeout: "30s"
+      start_period: "10m"
+      retries: 5
+    command: /run/start-celery
+    environment:
+      TZ: America/Toronto
+      SERVER_HOST: rodan2.simssa.ca
+      CELERY_JOB_QUEUE: celery
+    env_file:
+      - ./scripts/production.env
+    volumes:
+      - "resources_nfs:/rodan/data"
+
+  py3-celery:
+    image: "ddmal/rodan-python3-celery:v3.2.0"
+    deploy:
+      replicas: 1
+      resources:
+        reservations:
+          cpus: "2"
+          memory: 5G
+        limits:
+          cpus: "2"
+          memory: 5G
+      restart_policy:
+        condition: any
+        delay: 5s
+        window: 30s
+      placement:
+        constraints:
+          - node.role == manager
+    healthcheck:
+      test: ["CMD", "celery", "inspect", "ping", "-A", "rodan", "--workdir", "/code/Rodan", "-d", "celery@Python3", "-t", "30"]
+      interval: "30s"
+      timeout: "30s"
+      retries: 5
+    command: /run/start-celery
+    environment:
+      TZ: America/Toronto
+      SERVER_HOST: rodan2.simssa.ca
+      CELERY_JOB_QUEUE: Python3
+    env_file:
+      - ./scripts/production.env
+    volumes:
+      - "resources_nfs:/rodan/data"
+
+  gpu-celery:
+    image: "ddmal/rodan-gpu-celery:v3.2.0"
+    deploy:
+      replicas: 1
+      resources:
+        reservations:
+          cpus: "1"
+          memory: 18G
+        limits:
+          cpus: "1"
+          memory: 18G
+      placement:
+        constraints:
+          - node.role == manager
+      restart_policy:
+        condition: any
+        delay: 5s
+        window: 30s
+    healthcheck:
+      test: ["CMD", "celery", "inspect", "ping", "-A", "rodan", "--workdir", "/code/Rodan", "-d", "celery@GPU", "-t", "30"]
+      interval: "30s"
+      timeout: "30s"
+      retries: 5
+    command: /run/start-celery
+    environment:
+      TZ: America/Toronto
+      SERVER_HOST: rodan2.simssa.ca
+      CELERY_JOB_QUEUE: GPU
+    env_file:
+      - ./scripts/production.env
+    volumes:
+      - "resources_nfs:/rodan/data"
+
+  redis:
+    image: "redis:alpine"
+    deploy:
+      replicas: 1
+      resources:
+        reservations:
+          cpus: "1"
+          memory: 2G
+        limits:
+          cpus: "1"
+          memory: 2G
+      restart_policy:
+        condition: any
+        delay: 5s
+        window: 30s
+      placement:
+        constraints:
+          - node.role == worker
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    environment:
+      TZ: America/Toronto
+
+  postgres:
+    image: "ddmal/postgres-plpython:v3.2.0"
+    deploy:
+      replicas: 1
+      endpoint_mode: dnsrr
+      resources:
+        reservations:
+          cpus: "1"
+          memory: 2G
+        limits:
+          cpus: "1"
+          memory: 2G
+      restart_policy:
+        condition: any
+        delay: 5s
+        window: 30s
+      placement:
+        constraints:
+          - node.role == manager
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready", "-U", "postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    environment:
+      TZ: America/Toronto
+    volumes:
+      - "pg_data_nfs:/var/lib/postgresql/data"
+      - "pg_backup_nfs:/backups"
+    env_file:
+      - ./scripts/production.env
+
+  rabbitmq:
+    image: "rabbitmq:alpine"
+    deploy:
+      replicas: 1
+      resources:
+        reservations:
+          cpus: "2"
+          memory: 4G
+        limits:
+          cpus: "2"
+          memory: 4G
+      restart_policy:
+        condition: any
+        delay: 5s
+        window: 30s
+      placement:
+        constraints:
+          - node.role == worker
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: "30s"
+      timeout: "3s"
+      retries: 3
+    environment:
+      TZ: America/Toronto
+    env_file:
+      - ./scripts/production.env
+
+volumes:
+  resources_nfs:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=[ip address],rw,nfsvers=4,soft,timeo=600,retrans=3
+      device: "[ip address]:/var/lib/docker/volumes/rodan_resources/_data"
+  pg_backup_nfs:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=[ip address],rw,nfsvers=4
+      device: "[ip address]:/var/lib/docker/volumes/rodan_pg_backup/_data"
+  pg_data_nfs:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=[ip address],rw,nfsvers=4
+      device: "[ip address]:/var/lib/docker/volumes/rodan_pg_data/_data"

--- a/production.yml
+++ b/production.yml
@@ -3,7 +3,7 @@ version: "3.4"
 services:
 
   nginx:
-    image: "ddmal/nginx:v3.1.0"
+    image: "ddmal/nginx:v3.2.0"
     deploy:
       replicas: 1
       resources:
@@ -37,7 +37,7 @@ services:
       - "resources:/rodan/data"
 
   rodan-main:
-    image: "ddmal/rodan-main:v3.1.0"
+    image: "ddmal/rodan-main:v3.2.0"
     deploy:
       replicas: 1
       resources:
@@ -78,7 +78,7 @@ services:
       - "resources:/rodan/data"
 
   celery:
-    image: "ddmal/rodan-main:v3.1.0"
+    image: "ddmal/rodan-main:v3.2.0"
     deploy:
       replicas: 1
       resources:
@@ -109,7 +109,7 @@ services:
       - "resources:/rodan/data"
 
   py3-celery:
-    image: "ddmal/rodan-python3-celery:v3.1.0"
+    image: "ddmal/rodan-python3-celery:v3.2.0"
     deploy:
       replicas: 1
       resources:
@@ -139,7 +139,7 @@ services:
       - "resources:/rodan/data"
 
   gpu-celery:
-    image: "ddmal/rodan-gpu-celery:v3.1.0"
+    image: "ddmal/rodan-gpu-celery:v3.2.0"
     deploy:
       replicas: 1
       resources:
@@ -195,7 +195,7 @@ services:
       TZ: America/Toronto
 
   postgres:
-    image: "ddmal/postgres-plpython:v3.1.0"
+    image: "ddmal/postgres-plpython:v3.2.0"
     deploy:
       replicas: 1
       endpoint_mode: dnsrr

--- a/rodan-main/code/rodan/__init__.py
+++ b/rodan-main/code/rodan/__init__.py
@@ -17,7 +17,7 @@ from .celery import app as celery_app
 # Get version: import rodan; rodan.__version__
 # Version numbers also appear in the API.
 __title__ = "Rodan"
-__version__ = "v3.1.0"
+__version__ = "v3.2.0"
 __copyright__ = "Copyright 2011-2022 Distributed Digital Music Archives & Libraries Lab"
 # If changing this line, also change rodan-main/Dockerfile
 __build_hash__ = "local"

--- a/scripts/start
+++ b/scripts/start
@@ -8,7 +8,7 @@ set -o xtrace # Print commands and their arguments as they are executed.
 
 mkdir -p /var/www || echo '/var/www already exists, skipping'
 mkdir -p /code/Rodan/staticfiles || echo '/code/Rodan/staticfiles already exists, skipping'
-chmod -R a+rwx /rodan
+# chmod -R a+rwx /rodan
 chmod a+rwx /var
 chmod a+rwx /code/Rodan/*
 chmod a+rwx /code/Rodan/staticfiles

--- a/scripts/start-celery
+++ b/scripts/start-celery
@@ -5,7 +5,7 @@ set -o xtrace # Print commands and their arguments as they are executed.
 
 mkdir -p /var/www || echo '/var/www already exists, skipping'
 mkdir -p /code/Rodan/staticfiles || echo '/code/Rodan/staticfiles already exists, skipping'
-chmod -R a+rwx /rodan
+# chmod -R a+rwx /rodan
 chmod a+rwx /var
 chmod a+rwx /code/Rodan/*
 


### PR DESCRIPTION
Release v3.2.0

Fix: MEI default clef set to C4
Fix: MEI update to v5.1
Fix: Add liquescent element inside nc for MEI build
Fix: Pixel_wrapper
Add: Delete confirm window in rodan-client
Update: GitHub runner version

Resolves: (#ID-of-the-issue)
- [ ] I passed the docker hub test, and images can be built successfully.
- [ ] I passed the GitHub CI test, so rodan functionalities and jobs work.

(Describe the changes you've made and the purpose of this PR)