### PR TITLE
fix: tab & navigation status

### DIFF
--- a/rodan-client/code/src/js/Controllers/ControllerProject.js
+++ b/rodan-client/code/src/js/Controllers/ControllerProject.js
@@ -12,8 +12,8 @@ import ViewDeleteConfirm from '../Views/Master/Main/Shared/ViewDeleteConfirm';
 import ViewProject from 'js/Views/Master/Main/Project/Individual/ViewProject';
 import ViewProjectCollection from 'js/Views/Master/Main/Project/Collection/ViewProjectCollection';
 import ViewUserCollectionItem from 'js/Views/Master/Main/User/Collection/ViewUserCollectionItem';
-import ViewWorkflowRunCollection from 'js/Views/Master/Main/WorkflowRun/Collection/ViewWorkflowRunCollection';
-import WorkflowRunCollection from 'js/Collections/WorkflowRunCollection';
+import ViewResourceCollection from 'js/Views/Master/Main/Resource/Collection/ViewResourceCollection';
+import ResourceCollection from 'js/Collections/ResourceCollection';
 
 /**
  * Controller for Projects.
@@ -245,18 +245,27 @@ export default class ControllerProject extends BaseController {
      */
     _handleEventItemSelected(options) {
         this._activeProject = options.project;
-        this._activeProject.fetch();
-
-        // default collection inside project view is the workflowrun collection
-        var collection = new WorkflowRunCollection();
-        collection.fetch({ data: { project: this._activeProject.id } });
-        Radio.channel('rodan').request(RODAN_EVENTS.REQUEST__UPDATER_SET_COLLECTIONS, { collections: [collection] });
-        var viewProject = new ViewProject({ model: this._activeProject });
-        Radio.channel('rodan').request(RODAN_EVENTS.REQUEST__MAINREGION_SHOW_VIEW, {
-            view: viewProject,
-            options: { project: this._activeProject }
+        
+        // Fetch project first and wait for it to complete
+        this._activeProject.fetch({
+            success: () => {
+                // default collection inside project view is the resource collection
+                var collection = new ResourceCollection();
+                collection.fetch({ data: { project: this._activeProject.id } });
+                
+                // Set up view
+                Radio.channel('rodan').request(RODAN_EVENTS.REQUEST__UPDATER_SET_COLLECTIONS, { collections: [collection] });
+                var viewProject = new ViewProject({ model: this._activeProject });
+                Radio.channel('rodan').request(RODAN_EVENTS.REQUEST__MAINREGION_SHOW_VIEW, {
+                    view: viewProject,
+                    options: { project: this._activeProject }
+                });
+                
+                // Show resource collection by default and trigger resource selection event
+                viewProject.showCollection(new ViewResourceCollection({ collection: collection }));
+                Radio.channel('rodan').trigger(RODAN_EVENTS.EVENT__RESOURCE_SELECTED_COLLECTION, { project: this._activeProject });
+            }
         });
-        viewProject.showCollection(new ViewWorkflowRunCollection({ collection: collection }));
     }
 
     /**

--- a/rodan-client/code/src/js/Views/Master/Main/Project/Individual/ViewProject.js
+++ b/rodan-client/code/src/js/Views/Master/Main/Project/Individual/ViewProject.js
@@ -3,6 +3,10 @@ import _ from 'underscore';
 import RODAN_EVENTS from 'js/Shared/RODAN_EVENTS';
 import Marionette from 'backbone.marionette';
 import Radio from 'backbone.radio';
+import ViewResourceCollection from 'js/Views/Master/Main/Resource/Collection/ViewResourceCollection';
+import ViewWorkflowCollection from 'js/Views/Master/Main/Workflow/Collection/ViewWorkflowCollection';
+import ViewWorkflowRunCollection from 'js/Views/Master/Main/WorkflowRun/Collection/ViewWorkflowRunCollection';
+import ViewRunJobCollection from 'js/Views/Master/Main/RunJob/Collection/ViewRunJobCollection';
 
 /**
  * Project view.
@@ -27,6 +31,18 @@ export default class ViewProject extends Marionette.View {
      */
     showCollection(view) {
         this.showChildView('regionCollection', view);
+
+        // Update tab status based on view type
+        $('.project-nav-bar-btn').removeClass('active');
+        if (view instanceof ViewResourceCollection) {
+            $('#resource_count').addClass('active');
+        } else if (view instanceof ViewWorkflowCollection) {
+            $('#workflow_count').addClass('active');
+        } else if (view instanceof ViewWorkflowRunCollection) {
+            $('#button-workflow_runs').addClass('active');
+        } else if (view instanceof ViewRunJobCollection) {
+            $('#button-runjobs').addClass('active');
+        }
     }
 
     /**
@@ -82,8 +98,6 @@ export default class ViewProject extends Marionette.View {
      */
     _handleButtonRunJobs() {
         Radio.channel('rodan').trigger(RODAN_EVENTS.EVENT__RUNJOB_SELECTED_COLLECTION, { project: this.model });
-        $('.project-nav-bar-btn').removeClass('active');
-        $('#button-runjobs').addClass('active');
     }
 
     /**
@@ -91,8 +105,6 @@ export default class ViewProject extends Marionette.View {
      */
     _handleClickResourceCount() {
         Radio.channel('rodan').trigger(RODAN_EVENTS.EVENT__RESOURCE_SELECTED_COLLECTION, { project: this.model });
-        $('.project-nav-bar-btn').removeClass('active');
-        $('#resource_count').addClass('active');
     }
 
     /**
@@ -100,8 +112,6 @@ export default class ViewProject extends Marionette.View {
      */
     _handleClickWorkflowCount() {
         Radio.channel('rodan').trigger(RODAN_EVENTS.EVENT__WORKFLOW_SELECTED_COLLECTION, { view: this, project: this.model });
-        $('.project-nav-bar-btn').removeClass('active');
-        $('#workflow_count').addClass('active');
     }
 
     /**
@@ -109,8 +119,6 @@ export default class ViewProject extends Marionette.View {
      */
     _handleButtonWorkflowRuns() {
         Radio.channel('rodan').trigger(RODAN_EVENTS.EVENT__WORKFLOWRUN_SELECTED_COLLECTION, { project: this.model });
-        $('.project-nav-bar-btn').removeClass('active');
-        $('#button-workflow_runs').addClass('active');
     }
 
     /**

--- a/rodan-client/code/templates/Views/Master/Main/Project/Individual/template-main_project_individual.html
+++ b/rodan-client/code/templates/Views/Master/Main/Project/Individual/template-main_project_individual.html
@@ -9,10 +9,10 @@
         <!-- Project collections (workflow runs, resources, etc.) -->
         <div class="content-wrapper column-content project-collections padding-10">
             <div class="content-wrapper row-content project-navigation-bar">
-                <button class="btn project-nav-bar-btn active" id="button-workflow_runs">Workflow Runs</button>
-                <button class="btn project-nav-bar-btn" id="button-runjobs">Run Jobs</button>
+                <button class="btn project-nav-bar-btn" id="resource_count">Resources</button>
                 <button class="btn project-nav-bar-btn" id="workflow_count">Workflows</button>
-                <button class="btn project-nav-bar-btn" id="resource_count">Resources</button>                          
+                <button class="btn project-nav-bar-btn" id="button-workflow_runs">Workflow Runs</button>
+                <button class="btn project-nav-bar-btn" id="button-runjobs">Run Jobs</button>
                 <!-- <button class="btn project-nav-bar-btn" id="button-resourcelists">Resource Lists: <%= resourcelist_count%></button> -->            
             </div>
 
@@ -36,7 +36,7 @@
                     <div class="content-wrapper column-content  details-panel-details-section padding-10">
                         <div class="content-wrapper row-content details-item-container">
                             <label class="details-item-label" for="text-project_name">Name:</label>
-                            <input class="details-item-value" type="text" class="form-control" id="text-project_name" value="<%= _.unescape(name) %>" name="text-project_name">
+                            <input class="details-item-value form-control" type="text" id="text-project_name" value="<%= _.unescape(name) %>" name="text-project_name">
                         </div>
 
                         <div class="content-wrapper column-content details-item-container">


### PR DESCRIPTION
Resolves: #1121
- [ ] I passed the docker hub test, and images can be built successfully.
- [ ] I passed the GitHub CI test, so rodan functionalities and jobs work.

- Changed tab sequence to be the same with navigation
- Changed default content from workflow run to resource
- Moved tab active status update from on-click to show-view
- Fixed tab & navigation status sync