### PR TITLE
Update prod tag in Makefile to v3.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ REPLACE := perl -i -pe
 RODAN_PATH := ./rodan-main/code/rodan
 JOBS_PATH := $(RODAN_PATH)/jobs
 
-PROD_TAG := v3.1.0
+PROD_TAG := v3.2.0
 
 DOCKER_TAG := nightly
 


### PR DESCRIPTION
Resolves: (#1225)
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

very minor fix - the production tag should be updated from v3.1 to v3.2