### PR TITLE
Fix dockerfile debian repo

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -19,9 +19,11 @@ RUN export DJANGO_SECRET_KEY=localdev \
 FROM nginx:1.19
 
 # Install OS dependencies
-RUN apt-get -qq update \
-  && apt-get -qq install openssl certbot unzip -y \
-  && rm -rf /var/lib/apt/lists/*
+RUN sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list && \
+    sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list && \
+    apt-get -o Acquire::Check-Valid-Until=false update && \
+    apt-get install -y openssl certbot unzip && \
+    rm -rf /var/lib/apt/lists/*
 
 # Add configuration files.
 COPY ./config/nginx.conf     /etc/nginx/nginx.conf

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -18,6 +18,9 @@ RUN export DJANGO_SECRET_KEY=localdev \
 ###########################################################
 FROM nginx:1.19
 
+# prevents interactive prompts during package installation that would otherwise hang or break automated builds
+ENV DEBIAN_FRONTEND=noninteractive
+
 # Install OS dependencies
 RUN sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list && \
     sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list && \

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,5 +1,5 @@
 ARG VERSION
-FROM ddmal/rodan-main:${VERSION} as rodan-static
+FROM ddmal/rodan-main:${VERSION} AS rodan-static
 
 RUN touch /code/Rodan/database.log /code/Rodan/rodan.log
 


### PR DESCRIPTION
Resolves: (#1316)
- [x] I passed the docker hub test, and images can be built successfully.
- [x] I passed the GitHub CI test, so rodan functionalities and jobs work.

Fix `Dockerfile` in `nginx`:
- Update apt sources to use Debian archive URLs for buster
- Update `sources.list` URLs and disable expired metadata checks to allow `apt-get update` and package installation.
- Fix From-As case mismatch in Line 2