### PR TITLE
update prod ver from v3.2.0 to v3.3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ REPLACE := perl -i -pe
 RODAN_PATH := ./rodan-main/code/rodan
 JOBS_PATH := $(RODAN_PATH)/jobs
 
-PROD_TAG := v3.2.0
+PROD_TAG := v3.3.0
 
 DOCKER_TAG := nightly
 

--- a/production.yml
+++ b/production.yml
@@ -3,7 +3,7 @@ version: "3.4"
 services:
 
   nginx:
-    image: "ddmal/nginx:v3.2.0"
+    image: "ddmal/nginx:v3.3.0"
     deploy:
       replicas: 1
       resources:
@@ -37,7 +37,7 @@ services:
       - "resources:/rodan/data"
 
   rodan-main:
-    image: "ddmal/rodan-main:v3.2.0"
+    image: "ddmal/rodan-main:v3.3.0"
     deploy:
       replicas: 1
       resources:
@@ -78,7 +78,7 @@ services:
       - "resources:/rodan/data"
 
   celery:
-    image: "ddmal/rodan-main:v3.2.0"
+    image: "ddmal/rodan-main:v3.3.0"
     deploy:
       replicas: 1
       resources:
@@ -109,7 +109,7 @@ services:
       - "resources:/rodan/data"
 
   py3-celery:
-    image: "ddmal/rodan-python3-celery:v3.2.0"
+    image: "ddmal/rodan-python3-celery:v3.3.0"
     deploy:
       replicas: 1
       resources:
@@ -139,7 +139,7 @@ services:
       - "resources:/rodan/data"
 
   gpu-celery:
-    image: "ddmal/rodan-gpu-celery:v3.2.0"
+    image: "ddmal/rodan-gpu-celery:v3.3.0"
     deploy:
       replicas: 1
       resources:
@@ -195,7 +195,7 @@ services:
       TZ: America/Toronto
 
   postgres:
-    image: "ddmal/postgres-plpython:v3.2.0"
+    image: "ddmal/postgres-plpython:v3.3.0"
     deploy:
       replicas: 1
       endpoint_mode: dnsrr

--- a/rodan-main/code/rodan/__init__.py
+++ b/rodan-main/code/rodan/__init__.py
@@ -17,7 +17,7 @@ from .celery import app as celery_app
 # Get version: import rodan; rodan.__version__
 # Version numbers also appear in the API.
 __title__ = "Rodan"
-__version__ = "v3.2.0"
+__version__ = "v3.3.0"
 __copyright__ = "Copyright 2011-2022 Distributed Digital Music Archives & Libraries Lab"
 # If changing this line, also change rodan-main/Dockerfile
 __build_hash__ = "local"


### PR DESCRIPTION
Resolves: (#ID-of-the-issue)
- [ ] I passed the docker hub test, and images can be built successfully.
- [ ] I passed the GitHub CI test, so rodan functionalities and jobs work.

(Describe the changes you've made and the purpose of this PR)

Release v3.3.0

Fix
- Now support optional RGB Image input and output in `Column Split` job
- `MEI Encoding` job is now able to encode a variable number of lines, rather than hard coded 4, with a temporary fix for pitch errors due to a different number of lines than 4 by adjusting the clef position
- [frontend] Workflow job position x offset after reload
- [frontend] Hide dropdown menus on click away
- [frontend] Tab & navigation status

Add
- `Aquitanian Ref Line Finding` job
- [frontend] Delete confirm window for workflow (in addition to project)

Update
- Nginx Dockerfile with Debian archive
- Use DDMAL forked version of `Calamri` for `Text Alignment` job