### PR TITLE
MEI Encoding Column Split Fix

### DIFF
--- a/rodan-main/code/rodan/jobs/MEI_encoding/build_mei_file.py
+++ b/rodan-main/code/rodan/jobs/MEI_encoding/build_mei_file.py
@@ -540,7 +540,7 @@ def precompute_multi_column(
         @column_split_info: The column split information from the pitch finding JSON.
     """
     height = column_split_info["height"]
-    prev_column = 0
+    last_glyph = None
     for glyph in glyphs:
         curr_column = column_split_info["staff_to_column"][int(glyph["staff"])]
         glyph["bounding_box"] = translate_bbox(
@@ -550,11 +550,11 @@ def precompute_multi_column(
             curr_column,
         )
         glyph["column"] = curr_column
-        if glyph["system_begin"] and curr_column > prev_column:
-            glyph["column_begin"] = True
-            prev_column = curr_column
-        else:
-            glyph["column_begin"] = False
+        glyph["column_begin"] = False
+        if last_glyph != None:
+            if curr_column > last_glyph["column"]:
+                last_glyph["column_begin"] = True
+        last_glyph = glyph
 
     # translate staves
     for i, staff in enumerate(staves):


### PR DESCRIPTION
Resolves: (#1323)
- [ ] I passed the docker hub test, and images can be built successfully.
- [ ] I passed the GitHub CI test, so rodan functionalities and jobs work.

Fixes an issue in MEI Encoding with column splitting input where the first staff of the second column would be incorrectly marked as part of the first column. The issue was caused by the wrong `system_begin` being updated due to an incorrect condition. 
<img width="1536" height="2326" alt="demo-min_60" src="https://github.com/user-attachments/assets/e64bdf33-cbb4-4e0d-b458-2819639c6f73" />

The boxes were generated from an intermediate output during the job. The blue box in the first staff of the second column represents where the new column begin starts, but this should be at the last staff of the first column so the following staff is part of the second column. The condition was changed so the column begin starts right before the first note of the next column.

Rodan workflow:
<img width="175" height="108" alt="Screenshot 2025-10-22 192331" src="https://github.com/user-attachments/assets/1101b770-eaa2-4630-b3b1-d49c7aa24da6" />

Input files:
[MEI Encoding Inputs.zip](https://github.com/user-attachments/files/23063973/MEI.Encoding.Inputs.zip)

Neon output:
<img width="598" height="804" alt="Screenshot 2025-10-22 192318" src="https://github.com/user-attachments/assets/a577923b-62f2-4035-9aab-429aa22d680a" />




